### PR TITLE
Guard against nil in json->clj

### DIFF
--- a/src/clojure_lsp/main.clj
+++ b/src/clojure_lsp/main.clj
@@ -263,6 +263,9 @@
 
 (defn- json->clj [json-element]
   (cond
+    (nil? json-element)
+    nil
+
     (.isJsonNull json-element)
     nil
 


### PR DESCRIPTION
Hi!

I was interested in playing around with clojure-lsp as I believe it can be a great addition to the available tooling for Clojure, and to get started I thought of writing the Atom client plugin as that's an editor I don't use much and that can give me an isolated editor to play with clojure-lsp.

Here's the link: https://github.com/andrestylianos/atom-ide-clojure

Unfortunately it does not work with the current release version of clojure-lsp as it blows up with a nullPointerException. What I was able to figure out is that, with Atom, the call to `.getInitializationOptions` (in main.clj, line 329) returns `nil` causing `json->clj` to give the null pointer exception.

I hope just adding the check for `nil?` is an acceptable solution.