### PR TITLE
Fix a part of LanguageClient-neovim example configure

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ nnoremap <silent> crtl :call LanguageClient#workspace_executeCommand('thread-las
 nnoremap <silent> crml :call LanguageClient#workspace_executeCommand('move-to-let', [Expand('%:p'), line('.') - 1, col('.') - 1, input('Binding name: ')])<CR>
 nnoremap <silent> cril :call LanguageClient#workspace_executeCommand('introduce-let', [Expand('%:p'), line('.') - 1, col('.') - 1, input('Binding name: ')])<CR>
 nnoremap <silent> crel :call LanguageClient#workspace_executeCommand('expand-let', [Expand('%:p'), line('.') - 1, col('.') - 1])<CR>
-nnoremap <silent> cram :call LanguageClient#workspace_executeCommand('create-missing-libspec', [Expand('%:p'), line('.') - 1, col('.') - 1])<CR>
+nnoremap <silent> cram :call LanguageClient#workspace_executeCommand('add-missing-libspec', [Expand('%:p'), line('.') - 1, col('.') - 1])<CR>
 ```
 
 Other clients might provide a higher level interface to `workspace/executeCommand` you need to pass the path, line and column numbers.


### PR DESCRIPTION
I think it should be "add-missing-libspec" command in your example code of configuring LanguageClient-neovim example.

Thanks.