### PR TITLE
update emacs instructions to inhibit lsp indentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,7 @@ Using https://github.com/emacs-lsp the following works for registering clojure-l
                   :major-modes '(clojure-mode clojurec-mode clojurescript-mode)
                   :server-id 'clojure-lsp))
 (add-to-list 'lsp-language-id-configuration '(clojure-mode . "clojure-mode"))
+(setq lsp-enable-indentation nil)
 (add-hook 'clojure-mode-hook #'lsp)
 (add-hook 'clojurec-mode-hook #'lsp)
 (add-hook 'clojurescript-mode-hook #'lsp)


### PR DESCRIPTION
lsp _can_ indent but the clojure mode does not yet support this. leave
this to clojure-mode which is much better at the moment.