### PR TITLE
Apply defaults when initializationOptions are null

### DIFF
--- a/test/clojure_lsp/main_test.clj
+++ b/test/clojure_lsp/main_test.clj
@@ -1,0 +1,14 @@
+(ns clojure-lsp.main-test
+  (:require
+   [clojure-lsp.main :as main]
+   [clojure.test :refer :all])
+  (:import
+   (org.eclipse.lsp4j
+     InitializeParams)))
+
+(deftest test-client-settings
+  (testing "initializationOptions are null"
+    (let [params (InitializeParams.)]
+      (.setInitializationOptions params nil)
+      (is (= #{"src" "test"}
+             (get (main/client-settings params) "source-paths"))))))


### PR DESCRIPTION
Previously when a client sent null for the initializationOptions param,
the default client-settings would not be used and client-settings itself
would be nil. This change makes it so that the default client-settings
are used when initializationOptions is null.