### PR TITLE
Add ExecuteCommandProvider to server capabilities

### DIFF
--- a/src/clojure_lsp/main.clj
+++ b/src/clojure_lsp/main.clj
@@ -27,6 +27,7 @@
       DidSaveTextDocumentParams
       DocumentFormattingParams
       DocumentRangeFormattingParams
+      ExecuteCommandOptions
       ExecuteCommandParams
       InitializeParams
       InitializeResult
@@ -291,6 +292,8 @@
                                      (.setDefinitionProvider true)
                                      (.setDocumentFormattingProvider true)
                                      (.setDocumentRangeFormattingProvider true)
+                                     (.setExecuteCommandProvider (doto (ExecuteCommandOptions.)
+                                                                   (.setCommands (keys handlers/refactorings))))
                                      (.setTextDocumentSync (doto (TextDocumentSyncOptions.)
                                                              (.setOpenClose true)
                                                              (.setChange TextDocumentSyncKind/Full)


### PR DESCRIPTION
This makes clients aware of the commands supported by the server.