### PR TITLE
Set javac implicit:none option

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -18,6 +18,7 @@
   :main clojure-lsp.main
   :java-source-paths ["src-java"]
   :resource-paths ["resources" "lib/rewrite-clj-0.6.2-SNAPSHOT.jar"]
+  :javac-options ["-implicit:none"]
   :profiles {:dev {:plugins [[com.jakemccrary/lein-test-refresh "0.23.0"]
                              [lein-binplus "0.6.5"]]
                    :bin {:name "clojure-lsp"}}


### PR DESCRIPTION
The java build step references lsp4j's TextDocumentIdentifier from
ClojureExtensions.java. The compile step writes this class out to
target which means the classpath has two copies of TDI. This is
problematic because lsp4j is a signed jar and there's a classfile in
that package now that is not signed.

Here's a theory on what is happening (major credit to hiredman for
thinking through it): lsp4j is written not in java but in extend[1], a
sugar dialect of java. Extend writes a class file and also "readable
Java 8 compatible source code". When javac needs to understand classes
that are imported, it looks for the newer of class or java file. Since
the java file is an artifact and not a source, its possibly newer than
the class file so javac compiles the java file and spits it to
disk. Java allows preferring newer or source, but unfortunately not a
class file. It seems like the best we can do allow javac to compile
the class while compiling but prevent it from writing it with
"-implicit:none". The documentation for this option is included
below[2]:

    Controls the generation of class files for implicitly loaded
    source files. To automatically generate class files, use
    -implicit:class. To suppress class file generation, use
    -implicit:none. If this option is not specified, then the default
    is to automatically generate class files. In this case, the
    compiler issues a warning if any such class files are generated
    when also doing annotation processing. The warning is not issued
    when the -implicit option is set explicitly. See Searching for
    Types.

[1] [Extend: Java with spice](https://www.eclipse.org/xtend/)
[2] [javac documentation: implicit](https://docs.oracle.com/javase/8/docs/technotes/tools/windows/javac.html#BHCJJJAJ)