### PR TITLE
Add a diagnostic for calling a function with the wrong number of arguments

### DIFF
--- a/src/clojure_lsp/crawler.clj
+++ b/src/clojure_lsp/crawler.clj
@@ -86,7 +86,7 @@
           :when (when-let [relevant-function (last relevant-functions)]
                   (:sym relevant-function)
                   (try
-                    (not-any? #(supports-argc % argc) (:signatures relevant-function))
+                    (not-any? #(supports-argc % argc) (get-in relevant-function [:signatures :sexprs]))
                     (catch Exception e
                       false)))]
       {:range (shared/->range call-site)

--- a/src/clojure_lsp/crawler.clj
+++ b/src/clojure_lsp/crawler.clj
@@ -89,8 +89,8 @@
       {:range (shared/->range call-site)
        :code :wrong-arity
        :message (let [plural (not= argc 1)]
-                  (format "No overload supporting %d argument%s for function: %s"
-                          argc (if plural "s" "") (:str call-site)))
+                  (format "No overload %s for %d argument%s"
+                          (:str call-site) argc (if plural "s" "")))
        :severity 1})))
 
 (defn ^:private diagnose-unused-references [uri declared-references all-envs]

--- a/src/clojure_lsp/crawler.clj
+++ b/src/clojure_lsp/crawler.clj
@@ -70,7 +70,6 @@
 (def ignore-arity
   #{'clojure.core/defn     ; regex-like arglists
     'clojure.core/defmacro ; regex-like arglists
-    'clojure.core/format   ; return type annotation breaks clojure.core arglists
     })
 
 (defn ^:private supports-argc [signature argc]

--- a/src/clojure_lsp/crawler.clj
+++ b/src/clojure_lsp/crawler.clj
@@ -85,10 +85,7 @@
                 relevant-functions (filter #(->> % (:sym) (= function-sym)) function-references)]
           :when (when-let [relevant-function (last relevant-functions)]
                   (:sym relevant-function)
-                  (try
-                    (not-any? #(supports-argc % argc) (get-in relevant-function [:signatures :sexprs]))
-                    (catch Exception e
-                      false)))]
+                  (not-any? #(supports-argc % argc) (get-in relevant-function [:signatures :sexprs])))]
       {:range (shared/->range call-site)
        :code :wrong-arity
        :message (let [plural (not= argc 1)]

--- a/src/clojure_lsp/handlers.clj
+++ b/src/clojure_lsp/handlers.clj
@@ -363,7 +363,9 @@
       {:range (shared/->range cursor)
        :contents (case content-format
                    "markdown" (let [{:keys [sym tags]} cursor
-                                    signatures (some->> signatures (string/join "\n"))
+                                    signatures (some->> signatures
+                                                        (:strings)
+                                                        (string/join "\n"))
                                     tags (string/join " " tags)]
                                 {:kind "markdown"
                                  :value (cond-> (str "```\n" sym "\n```\n")
@@ -373,7 +375,7 @@
 
                    ;; default to plaintext
                    [(cond-> (select-keys cursor [:sym :tags])
-                      (seq signatures) (assoc :signatures signatures)
+                      (seq signatures) (assoc :signatures (:strings signatures))
                       :always (pr-str))])}
       {:contents []})))
 

--- a/src/clojure_lsp/parser.clj
+++ b/src/clojure_lsp/parser.clj
@@ -1135,5 +1135,5 @@
   (find-usages "(do #inst \"2019-04-04\")" :clj {})
   (z/sexpr (z/right (z/of-string "#(:a 1)")))
 
-  (find-usages "(deftype JSValue [val])" :clj)
+  (find-usages "(deftype JSValue [val])" :clj {})
   (z/sexpr (loc-at-pos code 1 2)))

--- a/src/clojure_lsp/parser.clj
+++ b/src/clojure_lsp/parser.clj
@@ -550,12 +550,20 @@
 
 (def check (fn [pred x] (when (pred x) x)))
 
+(defn is-params
+  [loc]
+  (or
+    (#{:vector :list} (z/tag loc))
+    ; z/tag could be :meta not :vector if there is a return type annotation
+    (vector? (z/sexpr loc))))
+
 (defn handle-function
   [op-loc _loc context scoped name-tags]
   (let [op-local? (local? op-loc)
         op-fn? (= "fn" (name (z/sexpr op-loc)))
         name-loc (z-right-sexpr op-loc)
-        params-loc (z/find op-loc (fn [loc] (#{:vector :list} (z/tag loc))))]
+        params-loc (z/find op-loc is-params)]
+    (log/warn "handle-function on name" (z/sexpr name-loc))
     (when (symbol? (z/sexpr name-loc))
       (cond
         op-fn? nil

--- a/src/clojure_lsp/parser.clj
+++ b/src/clojure_lsp/parser.clj
@@ -510,7 +510,8 @@
                                                    #{:declare :local}
                                                    #{:declare :public})
                                            :doc (:doc def-meta)
-                                           :signatures (args-to-sigs (:arglists def-meta))})
+                                           :signatures (some-> (:arglists def-meta)
+                                                               args-to-sigs)})
     (handle-rest (z-right-sexpr name-loc)
                  context scoped)))
 

--- a/src/clojure_lsp/parser.clj
+++ b/src/clojure_lsp/parser.clj
@@ -362,10 +362,13 @@
 
 (defn handle-thread
   [op-loc _loc context scoped]
-  (loop [sub-loc (zm/right op-loc)]
-    (when sub-loc
-      (handle-sexpr (zsub/subzip sub-loc) context scoped true)
-      (recur (zm/right sub-loc)))))
+  (let [value-loc (zm/right op-loc)]
+    (do
+      (find-usages* (zsub/subzip value-loc) context scoped)
+      (loop [sub-loc (zm/right value-loc)]
+        (when sub-loc
+          (handle-sexpr (zsub/subzip sub-loc) context scoped true)
+          (recur (zm/right sub-loc)))))))
 
 (defn add-libspec [libtype context scoped entry-loc prefix-ns]
   (let [entry-ns-loc (z/down entry-loc)

--- a/src/clojure_lsp/parser.clj
+++ b/src/clojure_lsp/parser.clj
@@ -908,7 +908,11 @@
     (let [op-loc (some-> loc (zm/down))]
       (cond
         (and op-loc (symbol? (z/sexpr op-loc)))
-        (let [usage (add-reference context scoped (z/node op-loc) {})
+        (let [argc (->> loc
+                        (z/node)
+                        (n/children)
+                        (count))
+              usage (add-reference context scoped (z/node op-loc) {:argc argc})
               handler (get *sexpr-handlers* (:sym usage))
               macro-def (get (:macro-defs @context) (:sym usage))]
           (cond

--- a/src/clojure_lsp/parser.clj
+++ b/src/clojure_lsp/parser.clj
@@ -508,7 +508,7 @@
                                                    #{:declare :public})
                                            :doc (:doc def-meta)
                                            :signatures (some-> (:arglists def-meta)
-                                                               arglists-to-signatures)})
+                                                               (arglists-to-signatures))})
     (handle-rest (z-right-sexpr name-loc)
                  context scoped)))
 

--- a/test/clojure_lsp/handlers_test.clj
+++ b/test/clojure_lsp/handlers_test.clj
@@ -96,7 +96,7 @@
                                                                        (->> (baz)
                                                                             (foo 1 2))
                                                                        (baz :p :q :r)
-                                                                       (bar))
+                                                                       bar)
                                                                      (cond-> 0
                                                                       int? (bar :a :b)
                                                                       false (foo)

--- a/test/clojure_lsp/handlers_test.clj
+++ b/test/clojure_lsp/handlers_test.clj
@@ -62,8 +62,8 @@
                                                                    [foo 1 (foo 5 6 7)]
                                                                    (foo)
                                                                    (foo 1)
-                                                                   (foo 1 2)
-                                                                   (foo 1 2 3 4)" :clj {})}})
+                                                                   (foo 1 ['a 'b])
+                                                                   (foo 1 2 3 {:k 1 :v 2})" :clj {})}})
     (let [usages (crawler/find-diagnostics #{} "file://a.clj" (get-in @db/db [:file-envs "file://a.clj"]))]
       (is (= ["No overload supporting 3 arguments for function: foo"
               "No overload supporting 0 arguments for function: foo"

--- a/test/clojure_lsp/handlers_test.clj
+++ b/test/clojure_lsp/handlers_test.clj
@@ -55,6 +55,10 @@
       (is (= "xx/bar" (get-in changes ["file://b.clj" 1 :new-text]))))))
 
 (deftest test-find-diagnostics
+  (testing "wrong arity"
+    (reset! db/db {:file-envs {"file://a.clj" (parser/find-usages "(defn foo ([x] x) ([x y] '(x y))) (foo 1) (foo 1 2) (foo 1 2 3)" :clj {})}})
+    (let [usages (crawler/find-diagnostics #{} "file://a.clj" (get-in @db/db [:file-envs "file://a.clj"]))]
+      (is (= ["Wrong number of arguments to function: foo"] (map :message usages)))))
   (testing "unused symbols"
     (reset! db/db {:file-envs
                    {"file://a.clj" (parser/find-usages "(ns a) (def bar ::bar)" :clj {})

--- a/test/clojure_lsp/handlers_test.clj
+++ b/test/clojure_lsp/handlers_test.clj
@@ -71,6 +71,9 @@
                                                                      (bar)
                                                                      (bar 1)
                                                                      (baz))
+                                                                   (cond->> [1 8 9]
+                                                                     int? (foo)
+                                                                     false (bar))
                                                                    (baz :broken :brokken [nil :ok :okay])
                                                                    (baz {bar baz foo :no?})
                                                                    (bar)

--- a/test/clojure_lsp/handlers_test.clj
+++ b/test/clojure_lsp/handlers_test.clj
@@ -58,6 +58,12 @@
   (testing "wrong arity"
     (reset! db/db {:file-envs {"file://a.clj" (parser/find-usages "(defn foo ([x] x) ([x y] (x y)))
                                                                    (defn bar [y & rest] (y (bar rest)))
+                                                                   (defn baz [{x :x y :y :as long}
+                                                                              {:keys [k v] :as short}
+                                                                              [_ a b]]
+                                                                     (x y k v a b long short))
+                                                                   (baz :broken :brokken [nil :ok :okay])
+                                                                   (baz {bar baz foo :no?})
                                                                    (bar)
                                                                    (bar {:a [:b]})
                                                                    (bar :one-fish :two-fish :red-fish :blue-fish)
@@ -69,7 +75,8 @@
                                                                    (foo 1 ['a 'b])
                                                                    (foo 1 2 3 {:k 1 :v 2})" :clj {})}})
     (let [usages (crawler/find-diagnostics #{} "file://a.clj" (get-in @db/db [:file-envs "file://a.clj"]))]
-      (is (= ["No overload supporting 0 arguments for function: bar"
+      (is (= ["No overload supporting 1 argument for function: baz"
+              "No overload supporting 0 arguments for function: bar"
               "No overload supporting 3 arguments for function: foo"
               "No overload supporting 0 arguments for function: foo"
               "No overload supporting 4 arguments for function: foo"]

--- a/test/clojure_lsp/handlers_test.clj
+++ b/test/clojure_lsp/handlers_test.clj
@@ -107,7 +107,7 @@
                (map :message usages)))))
     (testing "with annotations"
       (reset! db/db {:file-envs {"file://a.clj" (parser/find-usages "(defn foo {:added \"1.0\"} [x] (inc x))
-                                                                     (defn ^:private bar [^Class x & rest] (str x rest))
+                                                                     (defn ^:private bar ^String [^Class x & rest] (str x rest))
                                                                      (foo foo)
                                                                      (foo foo foo)
                                                                      (bar :a)

--- a/test/clojure_lsp/handlers_test.clj
+++ b/test/clojure_lsp/handlers_test.clj
@@ -93,6 +93,8 @@
                                                                        (bar))
                                                                      (-> 1
                                                                        (baz)
+                                                                       (->> (baz)
+                                                                            (foo 1 2))
                                                                        (baz :p :q :r)
                                                                        (bar))
                                                                      (cond-> 0

--- a/test/clojure_lsp/handlers_test.clj
+++ b/test/clojure_lsp/handlers_test.clj
@@ -62,6 +62,15 @@
                                                                               {:keys [k v] :as short}
                                                                               [_ a b]]
                                                                      (x y k v a b long short))
+                                                                   (->> :test
+                                                                     (foo :yoo)
+                                                                     (baz {:x 1 :y 2} :no)
+                                                                     (bar))
+                                                                   (-> 1
+                                                                     (foo)
+                                                                     (bar)
+                                                                     (bar 1)
+                                                                     (baz))
                                                                    (baz :broken :brokken [nil :ok :okay])
                                                                    (baz {bar baz foo :no?})
                                                                    (bar)
@@ -75,11 +84,12 @@
                                                                    (foo 1 ['a 'b])
                                                                    (foo 1 2 3 {:k 1 :v 2})" :clj {})}})
     (let [usages (crawler/find-diagnostics #{} "file://a.clj" (get-in @db/db [:file-envs "file://a.clj"]))]
-      (is (= ["No overload supporting 1 argument for function: baz"
-              "No overload supporting 0 arguments for function: bar"
-              "No overload supporting 3 arguments for function: foo"
-              "No overload supporting 0 arguments for function: foo"
-              "No overload supporting 4 arguments for function: foo"]
+      (is (= ["No overload baz for 1 argument"
+              "No overload baz for 1 argument"
+              "No overload bar for 0 arguments"
+              "No overload foo for 3 arguments"
+              "No overload foo for 0 arguments"
+              "No overload foo for 4 arguments"]
              (map :message usages)))))
   (testing "unused symbols"
     (reset! db/db {:file-envs

--- a/test/clojure_lsp/handlers_test.clj
+++ b/test/clojure_lsp/handlers_test.clj
@@ -66,7 +66,7 @@
                                                                      (foo :yoo)
                                                                      (baz {:x 1 :y 2} :no)
                                                                      (bar))
-                                                                   (-> 1
+                                                                   (-> (foo :moo)
                                                                      (foo)
                                                                      (bar)
                                                                      (bar 1)

--- a/test/clojure_lsp/handlers_test.clj
+++ b/test/clojure_lsp/handlers_test.clj
@@ -56,7 +56,11 @@
 
 (deftest test-find-diagnostics
   (testing "wrong arity"
-    (reset! db/db {:file-envs {"file://a.clj" (parser/find-usages "(defn foo ([x] x) ([x y] '(x y)))
+    (reset! db/db {:file-envs {"file://a.clj" (parser/find-usages "(defn foo ([x] x) ([x y] (x y)))
+                                                                   (defn bar [y & rest] (y (bar rest)))
+                                                                   (bar)
+                                                                   (bar {:a [:b]})
+                                                                   (bar :one-fish :two-fish :red-fish :blue-fish)
                                                                    [foo]
                                                                    {foo 1 2 3}
                                                                    [foo 1 (foo 5 6 7)]
@@ -65,7 +69,8 @@
                                                                    (foo 1 ['a 'b])
                                                                    (foo 1 2 3 {:k 1 :v 2})" :clj {})}})
     (let [usages (crawler/find-diagnostics #{} "file://a.clj" (get-in @db/db [:file-envs "file://a.clj"]))]
-      (is (= ["No overload supporting 3 arguments for function: foo"
+      (is (= ["No overload supporting 0 arguments for function: bar"
+              "No overload supporting 3 arguments for function: foo"
               "No overload supporting 0 arguments for function: foo"
               "No overload supporting 4 arguments for function: foo"]
              (map :message usages)))))

--- a/test/clojure_lsp/handlers_test.clj
+++ b/test/clojure_lsp/handlers_test.clj
@@ -116,12 +116,14 @@
         (is (= ["No overload foo for 2 arguments"]
                (map :message usages)))))
     (testing "for meta arglists"
-      (reset! db/db {:file-envs {"file://a.clj" (parser/find-usages "(def ^{:arglists '([x])
-                                                                            :static true}
-                                                                       foo (fn foo [x] (x 1 0)))
+      (reset! db/db {:file-envs {"file://a.clj" (parser/find-usages "(def
+                                                                       ^{:doc \"Don't use this\"
+                                                                         :arglists '([z])
+                                                                         :added \"1.17\"
+                                                                         :static true}
+                                                                       foo nil)
                                                                      (foo)
-                                                                     (foo 1)
-                                                                     (foo 1 -1)" :clj {})}})
+                                                                     (foo (foo :a :b))" :clj {})}})
       (let [usages (crawler/find-diagnostics #{} "file://a.clj" (get-in @db/db [:file-envs "file://a.clj"]))]
         (is (= ["No overload foo for 0 arguments"
                 "No overload foo for 2 arguments"]

--- a/test/clojure_lsp/handlers_test.clj
+++ b/test/clojure_lsp/handlers_test.clj
@@ -114,6 +114,17 @@
                                                                      (bar :a :b)" :clj {})}})
       (let [usages (crawler/find-diagnostics #{} "file://a.clj" (get-in @db/db [:file-envs "file://a.clj"]))]
         (is (= ["No overload foo for 2 arguments"]
+               (map :message usages)))))
+    (testing "for meta arglists"
+      (reset! db/db {:file-envs {"file://a.clj" (parser/find-usages "(def ^{:arglists '([x])
+                                                                            :static true}
+                                                                       foo (fn foo [x] (x 1 0)))
+                                                                     (foo)
+                                                                     (foo 1)
+                                                                     (foo 1 -1)" :clj {})}})
+      (let [usages (crawler/find-diagnostics #{} "file://a.clj" (get-in @db/db [:file-envs "file://a.clj"]))]
+        (is (= ["No overload foo for 0 arguments"
+                "No overload foo for 2 arguments"]
                (map :message usages))))))
   (testing "unused symbols"
     (reset! db/db {:file-envs

--- a/test/clojure_lsp/parser_test.clj
+++ b/test/clojure_lsp/parser_test.clj
@@ -378,7 +378,7 @@
       (is (= (:sym (nth usages 2 nil)) (:sym (nth usages 3 nil))))
       (is (= (:sym (nth usages-noopt 2 nil)) (:sym (nth usages-noopt 3 nil))))
       (is (= "docstring" (:doc (nth usages 1 nil))))
-      (is (= "[[a] [a b]]" (get-in (nth usages 1 nil) [:signatures :strings])))))
+      (is (= ["[a]" "[a b]"] (get-in (nth usages 1 nil) [:signatures :strings])))))
   (testing "deftest"
     (let [code "(ns user (:require clojure.test)) (clojure.test/deftest my-test)"
           usages (parser/find-usages code :clj {})]

--- a/test/clojure_lsp/parser_test.clj
+++ b/test/clojure_lsp/parser_test.clj
@@ -550,3 +550,10 @@
       (is (= ["[{b :b} :- Long c :- [S/Str]]"] (get-in a [:signatures :strings])))
       (is (= (:sym b) (:sym b2)))
       (is (= [u s a b c] (filter (comp #(contains? % :declare) :tags) usages))))))
+
+(deftest fncall-arity
+  (let [code "(defn x [y] y (-> 1 x (x) (x 2)))"
+        usages (parser/find-usages code :clj {})
+        [_ _ _ _ _  x1 x2 x3] usages]
+    (is (= 1 (:argc x1) (:argc x2)))
+    (is (= 2 (:argc x3)))))

--- a/test/clojure_lsp/parser_test.clj
+++ b/test/clojure_lsp/parser_test.clj
@@ -427,7 +427,7 @@
               :sym :foo/name
               :str ":foo/name"
               :file-type :clj
-              :signatures ["[_ b]"]}
+              :signatures ['[_ b]]}
              (dissoc (nth usages 4 nil) :col :row :end-row :end-col)))
       (is (= (:sym (nth usages 8 nil)) (:sym (nth usages 9 nil)))))))
 
@@ -517,7 +517,7 @@
     (is (= #{:declare :public} (:tags a)))
     (is (= 'user/a (:sym a)))
     (is (= "Docs" (:doc a)))
-    (is (= ["[b :- Long c :- [S/Str]]"] (:signatures a)))
+    (is (= ['[b :- Long c :- [S/Str]]] (:signatures a)))
     (is (= (:sym b) (:sym b2)))
     (is (= [u s a b c] (filter (comp #(contains? % :declare) :tags) usages))))
   (let [code "(ns user (:require [schema.core :as s])) (s/defn a [b c] b)"
@@ -526,6 +526,6 @@
     (is (= #{:declare :public} (:tags a)))
     (is (= 'user/a (:sym a)))
     (is (= nil (:doc a)))
-    (is (= ["[b c]"] (:signatures a)))
+    (is (= ['[b c]] (:signatures a)))
     (is (= (:sym b) (:sym b2)))
     (is (= [u s a b c] (filter (comp #(contains? % :declare) :tags) usages)))))

--- a/test/clojure_lsp/parser_test.clj
+++ b/test/clojure_lsp/parser_test.clj
@@ -378,7 +378,7 @@
       (is (= (:sym (nth usages 2 nil)) (:sym (nth usages 3 nil))))
       (is (= (:sym (nth usages-noopt 2 nil)) (:sym (nth usages-noopt 3 nil))))
       (is (= "docstring" (:doc (nth usages 1 nil))))
-      (is (= '[[a] [a b]] (:signatures (nth usages 1 nil))))))
+      (is (= "[[a] [a b]]" (get-in (nth usages 1 nil) [:signatures :strings])))))
   (testing "deftest"
     (let [code "(ns user (:require clojure.test)) (clojure.test/deftest my-test)"
           usages (parser/find-usages code :clj {})]
@@ -427,7 +427,8 @@
               :sym :foo/name
               :str ":foo/name"
               :file-type :clj
-              :signatures ['[_ b]]}
+              :signatures {:sexprs ['[_ b]]
+                           :strings ["[_ b]"]}}
              (dissoc (nth usages 4 nil) :col :row :end-row :end-col)))
       (is (= (:sym (nth usages 8 nil)) (:sym (nth usages 9 nil)))))))
 
@@ -517,7 +518,7 @@
     (is (= #{:declare :public} (:tags a)))
     (is (= 'user/a (:sym a)))
     (is (= "Docs" (:doc a)))
-    (is (= ['[b :- Long c :- [S/Str]]] (:signatures a)))
+    (is (= ["[b :- Long c :- [S/Str]]"] (get-in a [:signatures :strings])))
     (is (= (:sym b) (:sym b2)))
     (is (= [u s a b c] (filter (comp #(contains? % :declare) :tags) usages))))
   (let [code "(ns user (:require [schema.core :as s])) (s/defn a [b c] b)"
@@ -526,6 +527,6 @@
     (is (= #{:declare :public} (:tags a)))
     (is (= 'user/a (:sym a)))
     (is (= nil (:doc a)))
-    (is (= ['[b c]] (:signatures a)))
+    (is (= ["[b c]"] (get-in a [:signatures :strings])))
     (is (= (:sym b) (:sym b2)))
     (is (= [u s a b c] (filter (comp #(contains? % :declare) :tags) usages)))))

--- a/test/clojure_lsp/parser_test.clj
+++ b/test/clojure_lsp/parser_test.clj
@@ -44,7 +44,7 @@
 (deftest handle-fn-test
   (let [zloc (z/of-string "(fn [^String b])")
         context (volatile! {})]
-    (parser/handle-fn (z/next zloc) zloc context {})
+    (parser/handle-fn (z/next zloc) zloc context {} false)
     (is (= '{"java.lang.String" #{:norename}
              "b" #{:declare :param}}
            (into {} (map (juxt (comp name :sym) :tags) (:usages @context)))))))


### PR DESCRIPTION
Adds a diagnostic to check against supported arities of a function when it is called in references, fixes #62.