### PR TITLE
Add emacs doc on adding lein to path

### DIFF
--- a/README.md
+++ b/README.md
@@ -273,6 +273,10 @@ I tried making a client but my hello world attempt didn't seem to work. If someo
   :ensure t
   :commands lsp
   :config
+  ;; add paths to your local installation of project mgmt tools, like lein
+  (setenv "PATH" (concat
+                   "/usr/local/bin" path-separator
+                   (getenv "PATH")))
   (dolist (m '(clojure-mode
                clojurec-mode
                clojurescript-mode


### PR DESCRIPTION
If the path to project managers aren't added to `PATH` the crawler is unable to launch them as sub processes when launched from emacs.