### PR TITLE
Add workspace-symbol support

### DIFF
--- a/src/clojure_lsp/interop.clj
+++ b/src/clojure_lsp/interop.clj
@@ -21,6 +21,7 @@
       PublishDiagnosticsParams
       Range
       SymbolKind
+      SymbolInformation
       TextDocumentEdit
       TextEdit
       VersionedTextDocumentIdentifier
@@ -110,6 +111,12 @@
                                                   (DocumentHighlight. (:range m))))))
 
 (s/def ::document-highlights (s/coll-of ::document-highlight))
+
+(s/def ::symbol-information (s/and (s/keys :req-un [::name :symbol/kind ::location])
+                                   (s/conformer (fn [m]
+                                                  (SymbolInformation. (:name m) (:kind m) (:location m))))))
+
+(s/def ::workspace-symbols (s/coll-of ::symbol-information))
 
 (s/def ::severity (s/and integer?
                          (s/conformer #(DiagnosticSeverity/forValue %1))))


### PR DESCRIPTION
The lsp now supports the workspace symbol request. This allows to query
the whole workspace for a certain symbol and jump to it.