### PR TITLE
Add support for document-highlight

### DIFF
--- a/src/clojure_lsp/handlers.clj
+++ b/src/clojure_lsp/handlers.clj
@@ -341,6 +341,20 @@
                   e)))
          (into []))))
 
+(defn file-env-entry->document-highlight [{:keys [row end-row col end-col]}]
+  (let [r {:start {:line (dec row) :character (dec col)}
+           :end {:line (dec end-row) :character (dec end-col)}}]
+    {:range r}))
+
+(defn document-highlight [doc-id line column]
+  (let [file-envs (:file-envs @db/db)
+        local-env (get file-envs doc-id)
+        cursor (find-reference-under-cursor line column local-env (shared/uri->file-type doc-id))
+        sym (:sym cursor)
+         ]
+    (into [] (comp (filter #(= (:sym %) sym))
+                   (map file-env-entry->document-highlight)) local-env)))
+
 (def refactorings
   {"cycle-coll" #'refactor/cycle-coll
    "thread-first" #'refactor/thread-first

--- a/src/clojure_lsp/interop.clj
+++ b/src/clojure_lsp/interop.clj
@@ -11,6 +11,7 @@
       CompletionItemKind
       Diagnostic
       DiagnosticSeverity
+      DocumentHighlight
       DocumentSymbol
       Hover
       Location
@@ -103,6 +104,12 @@
 (s/def ::document-symbols (s/and (s/coll-of ::document-symbol)
                                  (s/conformer (fn [c]
                                                 (map #(Either/forRight %) c)))))
+
+(s/def ::document-highlight (s/and (s/keys :req-un [::range])
+                                   (s/conformer (fn [m]
+                                                  (DocumentHighlight. (:range m))))))
+
+(s/def ::document-highlights (s/coll-of ::document-highlight))
 
 (s/def ::severity (s/and integer?
                          (s/conformer #(DiagnosticSeverity/forValue %1))))

--- a/src/clojure_lsp/main.clj
+++ b/src/clojure_lsp/main.clj
@@ -241,7 +241,23 @@
                   (let [doc-id (interop/document->decoded-uri (.getTextDocument params))]
                     (interop/conform-or-log ::interop/document-symbols (#'handlers/document-symbol doc-id)))
                   (catch Exception e
-                    (log/error e))))))))))
+                    (log/error e)))))))))
+
+(^CompletableFuture documentHighlight [this ^TextDocumentPositionParams params]
+    (go :documentSymbol
+        (CompletableFuture/supplyAsync
+          (reify Supplier
+            (get [this]
+              (end
+                (try
+                  (let [doc-id (interop/document->decoded-uri (.getTextDocument params))
+                        pos (.getPosition params)
+                        line (inc (.getLine pos))
+                        column (inc (.getCharacter pos))]
+                    (interop/conform-or-log ::interop/document-highlights (#'handlers/document-highlight doc-id line column)))
+                  (catch Exception e
+                    (log/error e)))))))))
+)
 
 (deftype LSPWorkspaceService []
   WorkspaceService
@@ -307,6 +323,7 @@
                                      (.setDocumentFormattingProvider true)
                                      (.setDocumentRangeFormattingProvider true)
                                      (.setDocumentSymbolProvider true)
+                                     (.setDocumentHighlightProvider true)
                                      (.setExecuteCommandProvider (doto (ExecuteCommandOptions.)
                                                                    (.setCommands (keys handlers/refactorings))))
                                      (.setTextDocumentSync (doto (TextDocumentSyncOptions.)


### PR DESCRIPTION
LSP-Clients can now request to highlight all usages of the symbol at a
certain text position in the current file.