### PR TITLE
Bump clojure, nrepl, and jdbc versions.

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -1,4 +1,4 @@
-{:deps {org.clojure/clojure {:mvn/version "1.9.0"}
+{:deps {org.clojure/clojure {:mvn/version "1.10.1"}
         org.clojure/tools.reader {:mvn/version "1.2.2"}
         org.eclipse.lsp4j/org.eclipse.lsp4j {:mvn/version "0.8.1"  :exclusions [org.eclipse.xtend/org.eclipse.xtend.lib]}
         org.eclipse.xtend/org.eclipse.xtend.lib {:mvn/version "2.20.0" :exclusions [com.google.guava/guava]}
@@ -6,10 +6,10 @@
         rewrite-clj {:local/root "lib/rewrite-clj-0.6.2-SNAPSHOT.jar"}
         log4j/log4j {:mvn/version "1.2.17"}
         org.clojure/tools.logging {:mvn/version "0.3.1"}
-        org.clojure/tools.nrepl {:mvn/version "0.2.12"}
+        nrepl/nrepl {:mvn/version "0.6.0"}
         org.clojure/core.async {:mvn/version "0.4.474"}
         org.xerial/sqlite-jdbc {:mvn/version "3.21.0.1"}
-        funcool/clojure.jdbc {:mvn/version "0.9.0"}
+        seancorfield/next.jdbc {:mvn/version "1.0.13"}
         digest {:mvn/version "1.4.8"}
         cljfmt {:mvn/version "0.6.4" :exclusions [rewrite-cljs]}
         medley {:mvn/version "1.0.0"}

--- a/src/clojure_lsp/db.clj
+++ b/src/clojure_lsp/db.clj
@@ -3,7 +3,8 @@
    [clojure.edn :as edn]
    [clojure.tools.logging :as log]
    [clojure.java.io :as io]
-   [jdbc.core :as jdbc]
+   [next.jdbc :as jdbc]
+   [next.jdbc.result-set :as rs]
    [clojure.core.async :as async]))
 
 (defonce db (atom {:documents {}}))
@@ -14,24 +15,28 @@
 
 (defn make-spec [project-root]
   (let [lsp-db (io/file (str project-root) ".lsp" "sqlite.1.db")]
-    {:subprotocol "sqlite"
-     :subname (.getAbsolutePath lsp-db)}))
+    {:dbtype "sqlite"
+     :dbname (.getAbsolutePath lsp-db)}))
 
 (defn save-deps [project-root project-hash classpath jar-envs]
   (let [db-spec (make-spec project-root)]
-    (io/make-parents (:subname db-spec))
-    (with-open [conn (jdbc/connection db-spec)]
-      (jdbc/execute conn "drop table if exists project;")
-      (jdbc/execute conn "create table project (version text, root text unique, hash text, classpath text, jar_envs text);")
-      (jdbc/execute conn ["insert or replace into project
+    (io/make-parents (:dbname db-spec))
+    (with-open [conn (jdbc/get-connection db-spec)]
+      (jdbc/execute! conn ["drop table if exists project;"])
+      (jdbc/execute! conn ["create table project (version text, root text unique, hash text, classpath text, jar_envs text);"])
+      (jdbc/execute! conn ["insert or replace into project
                           (version, root, hash, classpath, jar_envs)
                           values (?,?,?,?,?);" (str version) (str project-root) project-hash (pr-str classpath) (pr-str jar-envs)]))))
 
 (defn read-deps [project-root]
   (try
-    (with-open [conn (jdbc/connection (make-spec project-root))]
+    (with-open [conn (jdbc/get-connection (make-spec project-root))]
       (let [project-row
-            (->> (jdbc/fetch conn ["select root, hash, classpath, jar_envs from project where root = ? and version = ?" (str project-root) (str version)])
+            (->> (jdbc/execute! conn
+                                ["select root, hash, classpath, jar_envs from project where root = ? and version = ?"
+                                 (str project-root)
+                                 (str version)]
+                                {:builder-fn rs/as-unqualified-lower-maps})
                  (first))]
         {:jar-envs (edn/read-string (:jar_envs project-row))
          :classpath (edn/read-string (:classpath project-row))

--- a/src/clojure_lsp/main.clj
+++ b/src/clojure_lsp/main.clj
@@ -5,7 +5,7 @@
     [clojure-lsp.interop :as interop]
     [clojure.core.async :as async]
     [clojure.tools.logging :as log]
-    [clojure.tools.nrepl.server :as nrepl.server]
+    [nrepl.server :as nrepl.server]
     [trptcolin.versioneer.core :as version])
   (:import
     (clojure_lsp ClojureExtensions)


### PR DESCRIPTION
NREPL was using ancient contrib version rather than the newer
nrepl/nrepl version.

Went to next.jdbc as funcool's jdbc is quite unloved these
days. Simple benchmarking i'm seeing a bit of a wash. Little faster on
first read which might be beneficial but takes a bit longer to warm up
but ultimately ends faster?

next.jdbc specifies 1.10.1 so i bumped that so there weren't any
conflicts in `lein deps :tree`.

```clojure
(doseq [_ (range 10)]
  (time (do (read-deps "/home/dan/projects/clojure/clojure-lsp") nil)))
"Elapsed time: 904.263157 msecs"
"Elapsed time: 838.518511 msecs"
"Elapsed time: 582.260209 msecs"
"Elapsed time: 416.626243 msecs"
"Elapsed time: 447.928508 msecs"
"Elapsed time: 424.89809 msecs"
"Elapsed time: 252.85043 msecs"
"Elapsed time: 216.117669 msecs"
"Elapsed time: 183.65135 msecs"
"Elapsed time: 171.96489 msecs"
nil
```

versus the old funcool:

```clojure
(doseq [_ (range 10)]
  (time (do (read-deps "/home/dan/projects/clojure/clojure-lsp") nil)))
"Elapsed time: 1126.990933 msecs"
"Elapsed time: 685.330829 msecs"
"Elapsed time: 538.112843 msecs"
"Elapsed time: 662.106515 msecs"
"Elapsed time: 370.966744 msecs"
"Elapsed time: 368.425031 msecs"
"Elapsed time: 205.441701 msecs"
"Elapsed time: 181.528966 msecs"
"Elapsed time: 268.328453 msecs"
"Elapsed time: 251.54556 msecs"
```

If you're not interested in this patch my feelings aren't hurt. Just throwing out a one-click upgrade deps for you in you're interested.