### PR TITLE
Add completion item resolve support

### DIFF
--- a/src/clojure_lsp/interop.clj
+++ b/src/clojure_lsp/interop.clj
@@ -50,16 +50,21 @@
 (s/def ::text-edit (s/and (s/keys :req-un [::new-text ::range])
                           (s/conformer #(TextEdit. (:range %1) (:new-text %1)))))
 (s/def ::additional-text-edits (s/coll-of ::text-edit))
+(s/def ::documentation (s/and (s/or :string string?
+                                    :markup-content ::markup-content)
+                              (s/conformer second)))
 (s/def ::completion-item (s/and (s/keys :req-un [::label]
-                                  :opt-un [::additional-text-edits ::filter-text ::detail ::text-edit :completion-item/kind])
-                                (s/conformer (fn [{:keys [label additional-text-edits filter-text detail text-edit kind]}]
+                                  :opt-un [::additional-text-edits ::filter-text ::detail ::text-edit :completion-item/kind ::documentation ::data])
+                                (s/conformer (fn [{:keys [label additional-text-edits filter-text detail text-edit kind documentation data]}]
                                                (let [item (CompletionItem. label)]
                                                  (cond-> item
                                                    filter-text (doto (.setFilterText filter-text))
                                                    kind (doto (.setKind kind))
                                                    additional-text-edits (doto (.setAdditionalTextEdits additional-text-edits))
                                                    detail (doto (.setDetail detail))
-                                                   text-edit (doto (.setTextEdit text-edit))))))))
+                                                   text-edit (doto (.setTextEdit text-edit))
+                                                   documentation (doto (.setDocumentation documentation))
+                                                   data (doto (.setData data))))))))
 (s/def ::completion-items (s/coll-of ::completion-item))
 (s/def ::version (s/and integer? (s/conformer int)))
 (s/def ::uri string?)


### PR DESCRIPTION
This PR adds support for the [completion item resolve request](https://microsoft.github.io/language-server-protocol/specifications/specification-3-14/#completionItem_resolve) so clojure-lsp could show some more detailed docs for the items when the user moves along the completion menu (normally displayed in a floating window next to the completion menu).

Currently this is done by filling the `data` field of each of the completion items with its symbol name when the completion menu is generated. Then when the user moves to an item in the menu, the LSP client sends over the original completion item with the `data` field, and clojure-lsp will return the documentation for that symbol.

PS: I'm sill familiarising myself with Clojure so I'd appreciate it if you would point out for me things not done right in the patch. Or if you're not happy with the quality, etc., feel free to close this. :)