### PR TITLE
Fix arity checking for schema.core/defn

### DIFF
--- a/src/clojure_lsp/parser.clj
+++ b/src/clojure_lsp/parser.clj
@@ -520,7 +520,7 @@
   (cond
     (= 'quote (first arglists))
     (let [sexprs (eval arglists)]
-      {:sexprs (clean-signature sexprs)
+      {:sexprs (map clean-signature sexprs)
        :strings (map str sexprs)})
 
     (string? (first arglists))
@@ -528,7 +528,7 @@
      :strings arglists}
 
     :else
-    {:sexprs (clean-signature (seq arglists))
+    {:sexprs (map clean-signature arglists)
      :strings (map str arglists)}))
 
 (defn handle-def

--- a/src/clojure_lsp/parser.clj
+++ b/src/clojure_lsp/parser.clj
@@ -551,8 +551,8 @@
 
 (defn- function-signatures
   ([params-loc] (function-signatures params-loc nil))
-  ([params-loc signature-style?]
-    (let [signature-fn (case signature-style?
+  ([params-loc signature-style]
+    (let [signature-fn (case signature-style
                          :typed remove-type-annots
                          identity)]
       (if (= :list (z/tag params-loc))
@@ -784,7 +784,7 @@
    'schema.core/defn [{:element :declaration
                        :doc? [{:pred :keyword} {:pred :follows-constant :constant :-}]
                        :attr-map? [{:pred :keyword} {:pred :follows-constant :constant :-} {:pred :string}]
-                       :signature-style? :typed
+                       :signature-style :typed
                        :signature [{:pred :keyword} {:pred :follows-constant :constant :-} {:pred :string} {:pred :map}]}
                       {:element :element :pred :keyword}
                       {:element :element :pred :follows-constant :constant :-}
@@ -819,11 +819,11 @@
           (recur next-loc dirs)
           next-loc)))))
 
-(defn- macro-declaration [{:keys [signature kind tags forward? doc? attr-map? signature-style? declare-class? ignore-arity?]} element-loc context scoped]
+(defn- macro-declaration [{:keys [signature kind tags forward? doc? attr-map? signature-style declare-class? ignore-arity?]} element-loc context scoped]
   (let [name-sexpr (z/sexpr element-loc)]
     (when (or (symbol? name-sexpr) (keyword? name-sexpr))
       (let [signature-loc (macro-dirs-to-loc signature element-loc)
-            signatures (when signature-loc (function-signatures signature-loc signature-style?))
+            signatures (when signature-loc (function-signatures signature-loc signature-style))
             doc-loc (cond
                       (vector? doc?) (macro-dirs-to-loc doc? element-loc)
                       doc? (z/find-next element-loc z/right (fn [loc]

--- a/src/clojure_lsp/parser.clj
+++ b/src/clojure_lsp/parser.clj
@@ -503,32 +503,20 @@
         (not (string/starts-with? op-name "def"))
         (string/ends-with? op-name "-"))))
 
-(defn clean-signature
-  "Remove `:- Type` type annotations from an fn signature sexpr."
-  [sexpr]
-  (loop [to-add sexpr
-         args []]
-    (if (seq to-add)
-      (let [[arg & xs] to-add]
-        (if (= arg :-)
-          (recur (drop 1 xs) args)
-          (recur xs (conj args arg))))
-      args)))
-
-(defn arglists-to-signatures
+(defn- arglists-to-signatures
   [arglists]
   (cond
     (= 'quote (first arglists))
     (let [sexprs (eval arglists)]
-      {:sexprs (map clean-signature sexprs)
+      {:sexprs (seq sexprs)
        :strings (map str sexprs)})
 
     (string? (first arglists))
-    {:sexprs (map (comp clean-signature z/sexpr z/of-string) arglists)
+    {:sexprs (map (comp z/sexpr z/of-string) arglists)
      :strings arglists}
 
     :else
-    {:sexprs (map clean-signature arglists)
+    {:sexprs (seq arglists)
      :strings (map str arglists)}))
 
 (defn handle-def
@@ -549,19 +537,36 @@
     (handle-rest (z-right-sexpr name-loc)
                  context scoped)))
 
-(defn- function-signatures [params-loc]
-  (if (= :list (z/tag params-loc))
-    (loop [list-loc params-loc
-           sexprs []
-           strings []]
-      (let [next-loc (z/down list-loc)
-            sexprs (conj sexprs (-> next-loc z/sexpr clean-signature))
-            strings (conj strings (z/string next-loc))]
-        (if-let [next-list (z/find-next-tag list-loc :list)]
-          (recur next-list sexprs strings)
-          {:sexprs sexprs :strings strings})))
-    {:sexprs [(-> params-loc z/sexpr clean-signature)]
-     :strings [(z/string params-loc)]}))
+(defn- remove-type-annots
+  "Remove `:- Type` type annotations from an fn signature sexpr."
+  [sexpr]
+  (loop [to-add sexpr
+         args []]
+    (if (seq to-add)
+      (let [[arg & xs] to-add]
+        (if (= arg :-)
+          (recur (drop 1 xs) args)
+          (recur xs (conj args arg))))
+      args)))
+
+(defn- function-signatures
+  ([params-loc] (function-signatures params-loc nil))
+  ([params-loc signature-style?]
+    (let [signature-fn (case signature-style?
+                         :typed remove-type-annots
+                         identity)]
+      (if (= :list (z/tag params-loc))
+        (loop [list-loc params-loc
+               sexprs []
+               strings []]
+          (let [next-loc (z/down list-loc)
+                sexprs (conj sexprs (-> next-loc z/sexpr signature-fn))
+                strings (conj strings (z/string next-loc))]
+            (if-let [next-list (z/find-next-tag list-loc :list)]
+              (recur next-list sexprs strings)
+              {:sexprs sexprs :strings strings})))
+        {:sexprs [(-> params-loc z/sexpr signature-fn)]
+         :strings [(z/string params-loc)]}))))
 
 (defn- single-params-and-body [params-loc context scoped]
   (let [body-loc (z-right-sexpr params-loc)]
@@ -660,7 +665,7 @@
     (vswap! context update :local-classes conj (z/sexpr type-loc))
     (add-reference context scoped (z/node type-loc) {:tags #{:declare :public}
                                                      :kind :class
-                                                     :signatures {:sexprs [(-> fields-loc z/sexpr clean-signature)]
+                                                     :signatures {:sexprs [(-> fields-loc z/sexpr)]
                                                                   :strings [(z/string fields-loc)]}})
     (when (= "defrecord" (name (z/sexpr op-loc)))
       (let [type-name (name (z/sexpr type-loc))
@@ -779,6 +784,7 @@
    'schema.core/defn [{:element :declaration
                        :doc? [{:pred :keyword} {:pred :follows-constant :constant :-}]
                        :attr-map? [{:pred :keyword} {:pred :follows-constant :constant :-} {:pred :string}]
+                       :signature-style? :typed
                        :signature [{:pred :keyword} {:pred :follows-constant :constant :-} {:pred :string} {:pred :map}]}
                       {:element :element :pred :keyword}
                       {:element :element :pred :follows-constant :constant :-}
@@ -813,11 +819,11 @@
           (recur next-loc dirs)
           next-loc)))))
 
-(defn- macro-declaration [{:keys [signature kind tags forward? doc? attr-map? declare-class? ignore-arity?]} element-loc context scoped]
+(defn- macro-declaration [{:keys [signature kind tags forward? doc? attr-map? signature-style? declare-class? ignore-arity?]} element-loc context scoped]
   (let [name-sexpr (z/sexpr element-loc)]
     (when (or (symbol? name-sexpr) (keyword? name-sexpr))
       (let [signature-loc (macro-dirs-to-loc signature element-loc)
-            signatures (when signature-loc (function-signatures signature-loc))
+            signatures (when signature-loc (function-signatures signature-loc signature-style?))
             doc-loc (cond
                       (vector? doc?) (macro-dirs-to-loc doc? element-loc)
                       doc? (z/find-next element-loc z/right (fn [loc]
@@ -852,6 +858,7 @@
                          (not forward?) (update :tags set/union (if op-local?  #{:declare :local} #{:declare :public}))
                          (:doc dec-meta) (assoc :doc (:doc dec-meta))
                          (:arglists dec-meta) (assoc :signatures (arglists-to-signatures (:arglists dec-meta)))
+                         (seq signatures) (assoc :signatures signatures)
                          kind (assoc :kind kind)))))))
 
 (defn- add-macro-sub-forms [element-loc context scope-bounds bound-scope sub-forms]

--- a/src/clojure_lsp/parser.clj
+++ b/src/clojure_lsp/parser.clj
@@ -779,8 +779,7 @@
    'schema.core/defn [{:element :declaration
                        :doc? [{:pred :keyword} {:pred :follows-constant :constant :-}]
                        :attr-map? [{:pred :keyword} {:pred :follows-constant :constant :-} {:pred :string}]
-                       :signature [{:pred :keyword} {:pred :follows-constant :constant :-} {:pred :string} {:pred :map}]
-                       :ignore-arity? true}
+                       :signature [{:pred :keyword} {:pred :follows-constant :constant :-} {:pred :string} {:pred :map}]}
                       {:element :element :pred :keyword}
                       {:element :element :pred :follows-constant :constant :-}
                       {:element :element :pred :string}

--- a/test/clojure_lsp/handlers_test.clj
+++ b/test/clojure_lsp/handlers_test.clj
@@ -140,7 +140,7 @@
                                                                      (foo 1 2)
                                                                      (foo 1)" :clj {})}})
       (let [usages (crawler/find-diagnostics #{} "file://a.clj" (get-in @db/db [:file-envs "file://a.clj"]))]
-        (is (= ["Unused ns user"
+        (is (= ["Unused namespace: user"
                 "No overload foo for 0 arguments"
                 "No overload foo for 1 argument"]
                (map :message usages))))))

--- a/test/clojure_lsp/handlers_test.clj
+++ b/test/clojure_lsp/handlers_test.clj
@@ -130,6 +130,19 @@
       (let [usages (crawler/find-diagnostics #{} "file://a.clj" (get-in @db/db [:file-envs "file://a.clj"]))]
         (is (= ["No overload foo for 0 arguments"
                 "No overload foo for 2 arguments"]
+               (map :message usages)))))
+    (testing "for schema defs"
+      (reset! db/db {:file-envs {"file://a.clj" (parser/find-usages "(ns user (:require [schema.core :as s]))
+                                                                     (s/defn foo :- s/Str
+                                                                       [x :- Long y :- Long]
+                                                                       (str x y))
+                                                                     (foo)
+                                                                     (foo 1 2)
+                                                                     (foo 1)" :clj {})}})
+      (let [usages (crawler/find-diagnostics #{} "file://a.clj" (get-in @db/db [:file-envs "file://a.clj"]))]
+        (is (= ["Unused ns user"
+                "No overload foo for 0 arguments"
+                "No overload foo for 1 argument"]
                (map :message usages))))))
   (testing "unused symbols"
     (reset! db/db {:file-envs

--- a/test/clojure_lsp/handlers_test.clj
+++ b/test/clojure_lsp/handlers_test.clj
@@ -148,6 +148,7 @@
       (let [usages  (parser/find-usages "(ns user (:require [schema.core :as s])) (s/defn foo [x :- int?] x) (foo 1 2 3)" :clj
                                         {'schema.core/defn [{:element :declaration
                                                              :signature [{:pred :keyword} {:pred :follows-constant :constant :-} {:pred :string} {:pred :map}]
+                                                             :signature-style? :typed
                                                              :ignore-arity? true}
                                                             {:element :sub-elements
                                                              :match-patterns [[:any :keyword :any] [:param :element :element]

--- a/test/clojure_lsp/parser_test.clj
+++ b/test/clojure_lsp/parser_test.clj
@@ -515,7 +515,7 @@
   (let [code "(ns user (:require [schema.core :as s])) (s/defn a [b c] b)"
         usages (parser/find-usages code :clj {})
         [_ u _ s _ a b c b2] usages]
-    (is (= #{:declare :public :ignore-arity?} (:tags a)))
+    (is (= #{:declare :public} (:tags a)))
     (is (= 'user/a (:sym a)))
     (is (= nil (:doc a)))
     (is (= ["[b c]"] (get-in a [:signatures :strings])))
@@ -524,7 +524,7 @@
   (let [code "(ns user (:require [schema.core :as s])) (s/defn a :- A \"Docs\" [b :- Long c :- [S/Str]] b)"
         usages (parser/find-usages code :clj {})
         [_ u _ s _ a _ _ b _ _ c _ _ b2] usages]
-    (is (= #{:declare :public :ignore-arity?} (:tags a)))
+    (is (= #{:declare :public} (:tags a)))
     (is (= 'user/a (:sym a)))
     (is (= "Docs" (:doc a)))
     (is (= ["[b :- Long c :- [S/Str]]"] (get-in a [:signatures :strings])))
@@ -534,7 +534,7 @@
     (let [code "(ns user (:require [schema.core :as s])) (s/defn a :- A \"Docs\" [{b :b} :- Long c :- [S/Str]] b)"
           usages (parser/find-usages code :clj {})
           [_ u _ s _ a _ _ _ b _ _ c _ _ b2] usages]
-      (is (= #{:declare :public :ignore-arity?} (:tags a)))
+      (is (= #{:declare :public} (:tags a)))
       (is (= 'user/a (:sym a)))
       (is (= "Docs" (:doc a)))
       (is (= ["[{b :b} :- Long c :- [S/Str]]"] (get-in a [:signatures :strings])))
@@ -545,7 +545,7 @@
     (let [code "(ns user (:require [schema.core :as s])) (s/defn a :- [A] \"Docs\" [{b :b} :- Long c :- [S/Str]] b)"
           usages (parser/find-usages code :clj {})
           [_ u _ s _ a _ _ _ b _ _ c _ _ b2] usages]
-      (is (= #{:declare :public :ignore-arity?} (:tags a)))
+      (is (= #{:declare :public} (:tags a)))
       (is (= 'user/a (:sym a)))
       (is (= "Docs" (:doc a)))
       (is (= ["[{b :b} :- Long c :- [S/Str]]"] (get-in a [:signatures :strings])))

--- a/test/clojure_lsp/parser_test.clj
+++ b/test/clojure_lsp/parser_test.clj
@@ -538,6 +538,7 @@
       (is (= 'user/a (:sym a)))
       (is (= "Docs" (:doc a)))
       (is (= ["[{b :b} :- Long c :- [S/Str]]"] (get-in a [:signatures :strings])))
+      (is (= ['[{b :b} c]] (get-in a [:signatures :sexprs])))
       (is (= (:sym b) (:sym b2)))
       (is (= [u s a b c] (filter (comp #(contains? % :declare) :tags) usages)))))
   (testing "handles complex return type"


### PR DESCRIPTION
Adds handling for `:-` type annotations in signatures, so things like in #104 don't have to be ignored.

As well as testing the arity checking here, I tried to keep the `:ignore-arity?` functionality tested with a client macro def in the test but I'm not sure if it should be tested differently, very welcome to suggestions.