### PR TITLE
Add support for shadow-cljs projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ Note: You may also consider configuring project specs via the (optional) `.lsp/c
                    :classpath-cmd ["clj" "-Spath"]}]}
    ```
 Each project-spec will add to the list of dependencies for lsp to crawl:
-  - `project-file` is the required filename used by your build tool (project.clj, build.boot, deps.edn, package.json, etc)
+  - `project-path` is the required filename used by your build tool (project.clj, build.boot, deps.edn, package.json, etc)
   - `classpath-cmd` is the required vector of commands to get your project's classpath string (e.g. `["clj", "-Spath"]`)
   - `env` optionally add environment variables to the classpath-cmd (e.g. `{"BOOT_FILE": "x.boot"}`)
 

--- a/src/clojure_lsp/crawler.clj
+++ b/src/clojure_lsp/crawler.clj
@@ -252,7 +252,9 @@
    {:project-path "deps.edn"
     :classpath-cmd ["clj" "-Spath"]}
    {:project-path "build.boot"
-    :classpath-cmd ["boot" "show" "--fake-classpath"]}])
+    :classpath-cmd ["boot" "show" "--fake-classpath"]}
+   {:project-path "shadow-cljs.edn"
+    :classpath-cmd ["shadow-cljs" "classpath"]}])
 
 (defn get-project-from [root-path project-specs]
   (reduce


### PR DESCRIPTION
As far as I can tell, everything seems to work once a classpath is
established. There are three ways to do so with shadow depending on
tooling:

1. shadow-cljs is installed globally and can be called
2. it is run with npm as `npx shadow-cljs ...`
3. it is run with yarn as `yarn shadow-cljs ...`

So just test the system for which are present and go with that. Yarn
and npx have the ability to have all of their output silenced with
--quiet and --silent so all we get back are classpaths.