### PR TITLE
Fix multi arity macro def

### DIFF
--- a/src/clojure_lsp/parser.clj
+++ b/src/clojure_lsp/parser.clj
@@ -796,10 +796,7 @@
                       {:element :element :pred :follows-constant :constant :-}
                       {:element :element :pred :string}
                       {:element :element :pred :map}
-                      {:element :sub-elements
-                       :match-patterns [[:any :keyword :any] [:param :element :element]
-                                        [:any] [:param]]}
-                      :bound-elements]})
+                      :function-params-and-bodies]})
 
 (defn- match-pred? [loc {:keys [pred constant]}]
   (let [sexpr (z/sexpr loc)]

--- a/test/clojure_lsp/handlers_test.clj
+++ b/test/clojure_lsp/handlers_test.clj
@@ -165,8 +165,14 @@
                                                             [c :as c]
                                                             [d :as d-alias]
                                                             [e :as e-alias]
-                                                            [clojure.spec.alpha :as s]))
+                                                            [clojure.spec.alpha :as s]
+                                                            [schema.core :as sc]))
                                                         (s/fdef wat)
+                                                        (sc/defn over :- s/Int
+                                                          ([a :- s/Int] a)
+                                                          ([a :- s/Int b :- s/Int] (+ a b)))
+                                                        (over 1)
+                                                        (over 2 :a)
                                                         (def x a/bar)
                                                         (declare y)
                                                         (defn y [])

--- a/test/clojure_lsp/parser_test.clj
+++ b/test/clojure_lsp/parser_test.clj
@@ -523,7 +523,7 @@
     (is (= [u s a b c] (filter (comp #(contains? % :declare) :tags) usages))))
   (let [code "(ns user (:require [schema.core :as s])) (s/defn a :- A \"Docs\" [b :- Long c :- [S/Str]] b)"
         usages (parser/find-usages code :clj {})
-        [_ u _ s _ a _ _ b _ _ c _ _ b2] usages]
+        [_ u _ s _ a _ _ b c b2] usages]
     (is (= #{:declare :public} (:tags a)))
     (is (= 'user/a (:sym a)))
     (is (= "Docs" (:doc a)))
@@ -533,7 +533,7 @@
   (testing "destructures param"
     (let [code "(ns user (:require [schema.core :as s])) (s/defn a :- A \"Docs\" [{b :b} :- Long c :- [S/Str]] b)"
           usages (parser/find-usages code :clj {})
-          [_ u _ s _ a _ _ _ b _ _ c _ _ b2] usages]
+          [_ u _ s _ a _ _ _ b c b2] usages]
       (is (= #{:declare :public} (:tags a)))
       (is (= 'user/a (:sym a)))
       (is (= "Docs" (:doc a)))
@@ -544,7 +544,7 @@
   (testing "handles complex return type"
     (let [code "(ns user (:require [schema.core :as s])) (s/defn a :- [A] \"Docs\" [{b :b} :- Long c :- [S/Str]] b)"
           usages (parser/find-usages code :clj {})
-          [_ u _ s _ a _ _ _ b _ _ c _ _ b2] usages]
+          [_ u _ s _ a _ _ _ b c b2] usages]
       (is (= #{:declare :public} (:tags a)))
       (is (= 'user/a (:sym a)))
       (is (= "Docs" (:doc a)))


### PR DESCRIPTION
Simple stop-gap fix which makes `schema.core/defn` use `:function-params-and-bodies` and allows `:signature-style :typed` for `:function-params-and-bodies` elements.

Fixes #108 