### PR TITLE
Fix docstring indentation weirdness on hover

### DIFF
--- a/src/clojure_lsp/handlers.clj
+++ b/src/clojure_lsp/handlers.clj
@@ -70,9 +70,11 @@
                             changes))}))
 
 (defn- drop-whitespace [n s]
-  (let [fully-trimmed (string/triml s)
-        dropped (subs s n)]
-    (last (sort-by count [fully-trimmed dropped]))))
+  (if (> n (count s))
+    s
+    (let [fully-trimmed (string/triml s)
+          dropped (subs s n)]
+      (last (sort-by count [fully-trimmed dropped])))))
 
 (defn- format-docstring [doc]
   (let [lines (string/split-lines doc)

--- a/src/clojure_lsp/handlers.clj
+++ b/src/clojure_lsp/handlers.clj
@@ -76,18 +76,18 @@
           dropped (subs s n)]
       (last (sort-by count [fully-trimmed dropped])))))
 
+(defn- count-whitespace [s]
+  (- (count s) (count (string/triml s))))
+
 (defn- format-docstring [doc]
   (let [lines (string/split-lines doc)
-        multi-line? (< 1 (count
-                           (filter (comp not string/blank?) lines)))]
+        other-lines (filter (comp not string/blank?) (rest lines))
+        multi-line? (> (count other-lines) 0)]
     (if-not multi-line?
       doc
-      (let [[first-line & rest-lines] lines
-            first-indented (first (drop-while string/blank? rest-lines))
-            indentation (- (count first-indented)
-                           (count (string/triml first-indented)))
-            unindented-lines (cons first-line
-                                   (map #(drop-whitespace indentation %) rest-lines))]
+      (let [indentation (apply min (map count-whitespace other-lines))
+            unindented-lines (cons (first lines)
+                                   (map #(drop-whitespace indentation %) (rest lines)))]
         (string/join "\n" unindented-lines)))))
 
 (defn- generate-docs [content-format usage]

--- a/src/clojure_lsp/handlers.clj
+++ b/src/clojure_lsp/handlers.clj
@@ -69,6 +69,19 @@
                               [(:uri text-document) edits])
                             changes))}))
 
+(defn format-docstring [doc]
+  (let [lines (string/split-lines doc)
+        multi-line? (< 1 (count lines))]
+    (if-not multi-line?
+      doc
+      (let [[first-line & rest-lines] lines
+            next-line (first rest-lines)
+            indentation (-
+                          (count next-line)
+                          (count (string/triml next-line)))
+            unindented-lines (cons first-line (map #(subs % indentation) rest-lines))]
+        (string/join "\n" unindented-lines)))))
+
 (defn- generate-docs [content-format usage]
   (let [{:keys [sym signatures doc tags]} usage
         signatures (some->> signatures
@@ -79,7 +92,7 @@
       "markdown" {:kind "markdown"
                   :value (cond-> (str "```\n" sym "\n```\n")
                            signatures (str "```\n" signatures "\n```\n")
-                           (seq doc) (str doc "\n")
+                           (seq doc) (str (format-docstring doc) "\n")
                            (seq tags) (str "\n----\n" "lsp: " tags))}
       ;; Default to plaintext
       (cond-> (str sym "\n")

--- a/src/clojure_lsp/handlers.clj
+++ b/src/clojure_lsp/handlers.clj
@@ -69,17 +69,23 @@
                               [(:uri text-document) edits])
                             changes))}))
 
-(defn format-docstring [doc]
+(defn- drop-whitespace [n s]
+  (let [fully-trimmed (string/triml s)
+        dropped (subs s n)]
+    (last (sort-by count [fully-trimmed dropped]))))
+
+(defn- format-docstring [doc]
   (let [lines (string/split-lines doc)
-        multi-line? (< 1 (count lines))]
+        multi-line? (< 1 (count
+                           (filter (comp not string/blank?) lines)))]
     (if-not multi-line?
       doc
       (let [[first-line & rest-lines] lines
-            next-line (first rest-lines)
-            indentation (-
-                          (count next-line)
-                          (count (string/triml next-line)))
-            unindented-lines (cons first-line (map #(subs % indentation) rest-lines))]
+            first-indented (first (drop-while string/blank? rest-lines))
+            indentation (- (count first-indented)
+                           (count (string/triml first-indented)))
+            unindented-lines (cons first-line
+                                   (map #(drop-whitespace indentation %) rest-lines))]
         (string/join "\n" unindented-lines)))))
 
 (defn- generate-docs [content-format usage]


### PR DESCRIPTION
When docstrings are wrapped onto multiple lines, an indentation is picked up on lines after the first line when they are aligned in the source, which leads to hover output like:

![alt text](https://i.imgur.com/NDnXjjj.png)

To fix this I added a `format-docstring` function that detects leading whitespace in the lines after the first, and removes it. With these changes we get:

![alt text](https://i.imgur.com/M859ELe.png)

It should only ever trim whitespace off the start of lines, so the worst case for very pathological inputs is the indentation looking bad again which I think is a fine trade-off for having the majority of cases look better.