### PR TITLE
Remove `c` as triggercharacters

### DIFF
--- a/src/clojure_lsp/main.clj
+++ b/src/clojure_lsp/main.clj
@@ -369,7 +369,7 @@
                                                              (.setOpenClose true)
                                                              (.setChange TextDocumentSyncKind/Full)
                                                              (.setSave (SaveOptions. true))))
-                                     (.setCompletionProvider (CompletionOptions. true [\c])))))))))
+                                     (.setCompletionProvider (CompletionOptions. true [])))))))))
     (^void initialized [^InitializedParams params]
       (log/warn "Initialized" params)
       (go :initialized


### PR DESCRIPTION
Trigger characters are characters that trigger the autocompletion but are not part of the result. With that the result of completing anything starting with `c` had an extra `c` appended to it