### PR TITLE
Add support for require at start on clean-ns

### DIFF
--- a/README.md
+++ b/README.md
@@ -320,3 +320,7 @@ In `lsp-mode` `lsp-clojure-server-command` defcustom is available to override th
 ### Others
 - Better completion item kinds and auto require
 - other lsp capabilities?
+
+## Building local
+
+For building local, run `lein bin` to generate the binary inside `target` folder.

--- a/README.md
+++ b/README.md
@@ -92,6 +92,8 @@ It is possible to pass some options to clojure-lsp through clients' `Initializat
 
 `use-metadata-for-privacy?` if true, will use `^:private` metadata for refactorings instead of `defn-`
 
+`keep-require-at-start?` if true, will keep first require at the first line instead of inserting a new line before it. 
+
 `dependency-scheme` by default, dependencies are linked with vim's `zipfile://<zipfile>::<innerfile>` scheme, however you can use a scheme of `jar` to get urls compatible with java's JarURLConnection. You can have the client make an lsp extension request of `clojure/dependencyContents` with the jar uri and the server will return the jar entry's contents. [Similar to java clients](https://github.com/redhat-developer/vscode-java/blob/a24945453092e1c39267eac9367c759a6c7b0497/src/extension.ts#L290-L298)
 
 `cljfmt` json encoded configuration for https://github.com/weavejester/cljfmt

--- a/src/clojure_lsp/refactor/transform.clj
+++ b/src/clojure_lsp/refactor/transform.clj
@@ -271,7 +271,7 @@
   (let [ns-loc (edit/find-namespace zloc)
         require-loc (z/find-value (zsub/subzip ns-loc) z/next :require)
         col (if require-loc
-              (dec (:col (meta (z/node (z/right require-loc)))))
+              (-> require-loc z/right z/node meta :col dec)
               4)
         sep (n/whitespace-node (apply str (repeat col " ")))
         single-space (n/whitespace-node " ")

--- a/src/clojure_lsp/refactor/transform.clj
+++ b/src/clojure_lsp/refactor/transform.clj
@@ -274,14 +274,20 @@
               (dec (:col (meta (z/node (z/right require-loc)))))
               4)
         sep (n/whitespace-node (apply str (repeat col " ")))
+        single-space (n/whitespace-node " ")
+        keep-require-at-start? (get-in @db/db [:settings "keep-require-at-start?"])
         requires (->> require-loc
                       z/remove
                       z/node
                       n/children
                       (remove n/printable-only?)
                       (sort-by (comp str n/sexpr))
-                      (mapcat (fn [node]
-                                [(n/newlines 1) sep node]))
+                      (map-indexed (fn [idx node]
+                                     (if (and keep-require-at-start?
+                                              (= idx 0))
+                                       [single-space node]
+                                       [(n/newlines 1) sep node])))
+                      (apply concat)
                       (cons (n/keyword-node :require)))
         result-loc (z/subedit-> ns-loc
                                 (z/find-value z/next :require)

--- a/test/clojure_lsp/refactor/transform_test.clj
+++ b/test/clojure_lsp/refactor/transform_test.clj
@@ -136,27 +136,27 @@
       (is (nil? (z/root-string loc))))))
 
 (deftest clean-ns-test
-  (reset! db/db {:settings {"keep-require-at-start?" false}})
-  (let [zloc (-> (z/of-string "(ns foo.bar\n  (:require\n    [c  :as x] a [b]))") z/down z/right z/right)
-        [{:keys [loc range]}] (transform/clean-ns zloc nil)]
-    (is (some? range))
-    (is (= (str "(ns foo.bar\n"
-                "  (:require\n"
-                "    [b]\n"
-                "    [c  :as x]\n"
-                "    a))")
-           (z/root-string loc)))))
-
-(deftest clean-ns-with-require-at-start-test
-  (reset! db/db {:settings {"keep-require-at-start?" true}})
-  (let [zloc (-> (z/of-string "(ns foo.bar\n  (:require [c  :as x] a [b]))") z/down z/right z/right)
-        [{:keys [loc range]}] (transform/clean-ns zloc nil)]
-    (is (some? range))
-    (is (= (str "(ns foo.bar\n"
-                "  (:require [b]\n"
-                "            [c  :as x]\n"
-                "            a))")
-           (z/root-string loc)))))
+  (testing "without keep-require-at-start?"
+    (reset! db/db {:settings {"keep-require-at-start?" false}})
+    (let [zloc (-> (z/of-string "(ns foo.bar\n  (:require\n    [c  :as x] a [b]))") z/down z/right z/right)
+          [{:keys [loc range]}] (transform/clean-ns zloc nil)]
+      (is (some? range))
+      (is (= (str "(ns foo.bar\n"
+                  "  (:require\n"
+                  "    [b]\n"
+                  "    [c  :as x]\n"
+                  "    a))")
+             (z/root-string loc)))))
+  (testing "with keep-require-at-start?"
+    (reset! db/db {:settings {"keep-require-at-start?" true}})
+    (let [zloc (-> (z/of-string "(ns foo.bar\n  (:require [c  :as x] a [b]))") z/down z/right z/right)
+          [{:keys [loc range]}] (transform/clean-ns zloc nil)]
+      (is (some? range))
+      (is (= (str "(ns foo.bar\n"
+                  "  (:require [b]\n"
+                  "            [c  :as x]\n"
+                  "            a))")
+             (z/root-string loc))))))
 
 (deftest add-missing-libspec
   (reset! db/db {:file-envs

--- a/test/clojure_lsp/refactor/transform_test.clj
+++ b/test/clojure_lsp/refactor/transform_test.clj
@@ -136,6 +136,7 @@
       (is (nil? (z/root-string loc))))))
 
 (deftest clean-ns-test
+  (reset! db/db {:settings {"keep-require-at-start?" false}})
   (let [zloc (-> (z/of-string "(ns foo.bar\n  (:require\n    [c  :as x] a [b]))") z/down z/right z/right)
         [{:keys [loc range]}] (transform/clean-ns zloc nil)]
     (is (some? range))
@@ -144,6 +145,17 @@
                 "    [b]\n"
                 "    [c  :as x]\n"
                 "    a))")
+           (z/root-string loc)))))
+
+(deftest clean-ns-with-require-at-start-test
+  (reset! db/db {:settings {"keep-require-at-start?" true}})
+  (let [zloc (-> (z/of-string "(ns foo.bar\n  (:require [c  :as x] a [b]))") z/down z/right z/right)
+        [{:keys [loc range]}] (transform/clean-ns zloc nil)]
+    (is (some? range))
+    (is (= (str "(ns foo.bar\n"
+                "  (:require [b]\n"
+                "            [c  :as x]\n"
+                "            a))")
            (z/root-string loc)))))
 
 (deftest add-missing-libspec


### PR DESCRIPTION
It's pretty common at [Nubank](https://github.com/nubank) use the `good` approach from [clojure-style-guide](https://github.com/bbatsov/clojure-style-guide#line-breaks-in-ns) for the `requires` indentations.
This PR adds support for a new optional flag `keep-require-at-start?` that keep the requires at the start without skipping the first line:

Before:
```clojure
(:require 
          [abc :as a]
          [def :as d])
```

After:
```clojure
(:require [abc :as a]
          [def :as d])
```