### PR TITLE
Remove unused aliases on clean-ns

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ All commands expect the first three args to be `[document-uri, line, column]` (e
 | done | command             | args | notes |
 | ---- | ------------------- | ---- | ----- |
 |   √  | add-missing-libspec | | |
-|   -  | clean-ns            | | | :require sort only
+|   -  | clean-ns            | | | :require sort and remove unused only
 |   √  | cycle-coll          | | |
 |   √  | cycle-privacy       | | |
 |   √  | expand-let          | | |


### PR DESCRIPTION
On clean-ns now we find the unused aliases then on formatting remove it the alias is unused.

Finally, we don't need to start CIDER to clean-ns :tada: 