### PR TITLE
Bump leiningen to 2.9.3

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   build:
     docker:
-      - image: circleci/clojure:lein-2.7.1
+      - image: circleci/clojure:lein-2.9.3
     working_directory: ~/repo
 
     environment:


### PR DESCRIPTION
relates to https://github.com/Homebrew/homebrew-core/pull/54447

homebrew side is always shipping with the latest `leiningen` build, so good to keep the circle-ci dependency up to date as well.