### PR TITLE
Prevent "clojure-lsp.crawler: Cannot parse" failure

### DIFF
--- a/src/clojure_lsp/crawler.clj
+++ b/src/clojure_lsp/crawler.clj
@@ -137,11 +137,12 @@
 
 (defn ^:private process-unused-aliases
   [usages declared-aliases]
-  (->> usages
-       (remove (comp #(contains? % :declare) :tags))
-       (map #(some-> % :sym namespace symbol))
-       set
-       (set/difference (set (map :ns declared-aliases)))))
+  (let [ensure-sym (fn [s] (when (symbol? s) s))]
+    (->> usages
+         (remove (comp #(contains? % :declare) :tags))
+         (map #(some-> % :sym ensure-sym namespace symbol))
+         set
+         (set/difference (set (map :ns declared-aliases))))))
 
 (defn ^:private diagnose-unused-aliases [_uri declared-aliases unused-aliases]
   (for [usage (filter (comp unused-aliases :ns) declared-aliases)]

--- a/src/clojure_lsp/crawler.clj
+++ b/src/clojure_lsp/crawler.clj
@@ -137,7 +137,7 @@
 
 (defn ^:private process-unused-aliases
   [usages declared-aliases]
-  (let [ensure-sym (fn [s] (when (symbol? s) s))]
+  (let [ensure-sym (fn [s] (when-not (string? s) s))]
     (->> usages
          (remove (comp #(contains? % :declare) :tags))
          (map #(some-> % :sym ensure-sym namespace symbol))


### PR DESCRIPTION
Hi, thank you for developing this great tool!

shadow-cljs project uses a [special syntax](https://shadow-cljs.github.io/docs/UsersGuide.html#_using_npm_packages) to require npm package like this `(ns .. (require ["react-dom" :refer [react]])`, notice using string (this allows multi-level module path) in place of namespace symbol. This syntax causes parse failure in clojure-lsp.crawler due to  `java.lang.ClassCastException: java.lang.String cannot be cast to clojure.lang.Named`.

It's a little sad to lose everything clojure-lsp provides due to this. The PR adds a simple check to prevent ClassCastException from happening. It seems not breaking anything else either.

Fix issue - https://github.com/snoe/clojure-lsp/issues/133#issue-615371044

Thanks!  