### PR TITLE
Add code actions handler

### DIFF
--- a/src/clojure_lsp/handlers.clj
+++ b/src/clojure_lsp/handlers.clj
@@ -539,3 +539,21 @@
                    (-> db
                        (update :documents #(apply dissoc % uris))
                        (update :file-envs #(apply dissoc % uris)))))))
+
+(defn code-actions
+  [uri line character]
+  (cond-> []
+
+    (get-in @db/db [:client-capabilities :workspace :workspace-edit])
+    (conj {:title   "Clean namespace"
+           :kind    :source-organize-imports
+           :command {:title     "Clean namespace"
+                     :command   "clean-ns"
+                     :arguments [uri line character]}})
+
+    true
+    (conj {:title   "Add missing namespace"
+           :kind    :source
+           :command {:title     "add-missing-libspec"
+                     :command   "add-missing-libspec"
+                     :arguments [uri line character]}})))

--- a/src/clojure_lsp/main.clj
+++ b/src/clojure_lsp/main.clj
@@ -13,6 +13,7 @@
     (org.eclipse.lsp4j
       ApplyWorkspaceEditParams
       CodeActionParams
+      CodeAction
       Command
       CompletionItem
       CompletionItemKind
@@ -227,14 +228,18 @@
             (CompletableFuture/completedFuture
               result)))))
 
-  #_
   (^CompletableFuture codeAction [_ ^CodeActionParams params]
-    (go :codeAction
-        (end
-          (CompletableFuture/completedFuture
-            (let [start (.getStart (.getRange params))]
-              [(Command. "add-missing-libspec" "add-missing-libspec"
-                         [(interop/document->decoded-uri (.getTextDocument params)) (.getLine start) (.getCharacter start)])])))))
+   (go :codeAction
+       (end
+         (CompletableFuture/completedFuture
+           (try
+             (let [uri             (interop/document->decoded-uri (.getTextDocument params))
+                   start           (.getStart (.getRange params))
+                   start-line      (.getLine start)
+                   start-character (.getCharacter start)]
+               (interop/conform-or-log ::interop/code-actions (#'handlers/code-actions uri start-line start-character)))
+             (catch Exception e
+               (log/error e)))))))
 
   (^CompletableFuture definition [this ^TextDocumentPositionParams params]
     (go :definition
@@ -354,7 +359,7 @@
               (CompletableFuture/completedFuture
                 (InitializeResult. (doto (ServerCapabilities.)
                                      (.setHoverProvider true)
-                                     (.setCodeActionProvider false)
+                                     (.setCodeActionProvider true)
                                      (.setReferencesProvider true)
                                      (.setRenameProvider true)
                                      (.setDefinitionProvider true)

--- a/src/clojure_lsp/main.clj
+++ b/src/clojure_lsp/main.clj
@@ -233,11 +233,12 @@
        (end
          (CompletableFuture/completedFuture
            (try
-             (let [uri             (interop/document->decoded-uri (.getTextDocument params))
+             (let [doc-id          (interop/document->decoded-uri (.getTextDocument params))
+                   diagnostics     (.getDiagnostics (.getContext params))
                    start           (.getStart (.getRange params))
                    start-line      (.getLine start)
                    start-character (.getCharacter start)]
-               (interop/conform-or-log ::interop/code-actions (#'handlers/code-actions uri start-line start-character)))
+               (interop/conform-or-log ::interop/code-actions (#'handlers/code-actions doc-id diagnostics start-line start-character)))
              (catch Exception e
                (log/error e)))))))
 

--- a/src/clojure_lsp/refactor/transform.clj
+++ b/src/clojure_lsp/refactor/transform.clj
@@ -344,7 +344,7 @@
                                    (or
                                      (set/subset? #{:public :ns} (:tags usage))
                                      (get-in usage [:tags :alias]))))
-                         (mapv (fn [{:keys [sym tags] alias-str :str alias-ns :ns :as usage}]
+                         (mapv (fn [{:keys [sym _tags] alias-str :str alias-ns :ns}]
                                  {:alias-str alias-str
                                   :label (name sym)
                                   :detail (if alias-ns

--- a/test/clojure_lsp/handlers_test.clj
+++ b/test/clojure_lsp/handlers_test.clj
@@ -275,11 +275,11 @@
 (deftest test-code-actions
   (let [a-code (str "(ns some-ns)\n"
                     "(def foo)")
-        b-code (str "(ns other-ns (:require [some-ns :as somens])\n"
-                    "(def bar")
+        b-code (str "(ns other-ns (:require [some-ns :as sns]))\n"
+                    "(def bar)")
         c-code (str "(ns another-ns)\n"
-                    "(def foo somens/foo)\n"
-                    "(def bar otherns/bar)")
+                    "(def bar ons/bar)\n"
+                    "(def foo sns/foo)")
         db-state {:documents {"file://a.clj" {:text a-code}
                               "file://b.clj" {:text b-code}
                               "file://c.clj" {:text c-code}}
@@ -298,16 +298,19 @@
                          :command   "clean-ns"
                          :arguments ["file://b.clj" 1 1]}}] (handlers/code-actions "file://b.clj" [] 1 1))))
 
+    (testing "Add missing libspec when it has not unknow-ns diagnostic"
+      (reset! db/db db-state)
+      (is (= []
+             (handlers/code-actions "file://c.clj" [] 1 9))))
+
+    (testing "Add missing libspec when it has unknow-ns but cannot find namespace"
+      (reset! db/db db-state)
+      (let [unknown-ns-diagnostic (Diagnostic. (Range. (Position. 1 10) (Position. 1 16)) "Unknown namespace" DiagnosticSeverity/Error "some source" "unknown-ns")]
+        (is (= []
+               (handlers/code-actions "file://c.clj" [unknown-ns-diagnostic] 1 10)))))
+
     (testing "Add missing libspec when it has unknow-ns and can find namespace"
       (reset! db/db db-state)
-      (let [unknown-ns-diagnostic (Diagnostic. (Range. (Position. 1 9) (Position. 1 9)) "Unknown namespace" DiagnosticSeverity/Error "some source" "unknown-ns")]
-        (is (= [{:title "Add missing namespace"
-                 :kind :quick-fix
-                 :workspace-edit
-                 {:changes
-                  {"file://c.clj"
-                   [{:range
-                     {:start {:line 0 :character 0} :end {:line 0 :character 15}}
-                     :new-text
-                     "(ns another-ns \n  (:require\n    [{\"some-ns\" [{:alias-str \"some-ns\", :label \"some-ns\", :detail \"some-ns\", :alias-ns some-ns}], \"another-ns\" [{:alias-str \"another-ns\", :label \"another-ns\", :detail \"another-ns\", :alias-ns another-ns}]} :as somens]))"}]}}}]
-               (handlers/code-actions "file://c.clj" [unknown-ns-diagnostic] 1 9)))))))
+      (let [unknown-ns-diagnostic (Diagnostic. (Range. (Position. 2 10) (Position. 2 16)) "Unknown namespace" DiagnosticSeverity/Error "some source" "unknown-ns")]
+        (is (= 1
+               (count (handlers/code-actions "file://c.clj" [unknown-ns-diagnostic] 2 10))))))))


### PR DESCRIPTION
Implement LSP code actions support adding 2 code actions:

* Clean namespace
* Add missing namespace - showing only when there is a `unknow-ns` on diagnostics and the server can really add that missing namespace.

We can add more code actions latter :)