### PR TITLE
Improve hover markdown and arity

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,8 @@ It is possible to pass some options to clojure-lsp through clients' `Initializat
 
 `keep-require-at-start?` if true, will keep first require at the first line instead of inserting a new line before it.
 
+`show-docs-arity-on-same-line?` if true, will keep the arity on the same line of the function on hover, useful for Emacs users.
+
 `dependency-scheme` by default, dependencies are linked with vim's `zipfile://<zipfile>::<innerfile>` scheme, however you can use a scheme of `jar` to get urls compatible with java's JarURLConnection. You can have the client make an lsp extension request of `clojure/dependencyContents` with the jar uri and the server will return the jar entry's contents. [Similar to java clients](https://github.com/redhat-developer/vscode-java/blob/a24945453092e1c39267eac9367c759a6c7b0497/src/extension.ts#L290-L298)
 
 `cljfmt` json encoded configuration for https://github.com/weavejester/cljfmt

--- a/src/clojure_lsp/handlers.clj
+++ b/src/clojure_lsp/handlers.clj
@@ -97,6 +97,11 @@
         signatures (some->> signatures
                             (:strings)
                             (string/join "\n"))
+        signatures (if (and show-docs-arity-on-same-line? signatures)
+                     (-> signatures
+                         (clojure.string/replace #"\n" ",")
+                         (clojure.string/replace #"  +" " "))
+                     signatures)
         tags (string/join " " tags)]
     (case content-format
       "markdown" {:kind "markdown"

--- a/src/clojure_lsp/handlers.clj
+++ b/src/clojure_lsp/handlers.clj
@@ -100,13 +100,11 @@
         tags (string/join " " tags)]
     (case content-format
       "markdown" {:kind "markdown"
-                  :value (cond-> (str "```\n" sym "\n```\n")
-                           signatures (str "```\n" signatures "\n```\n")
+                  :value (cond-> (str "```clojure\n" sym " " signatures "\n```\n")
                            (seq doc) (str (format-docstring doc) "\n")
                            (seq tags) (str "\n----\n" "lsp: " tags))}
       ;; Default to plaintext
-      (cond-> (str sym "\n")
-        signatures (str signatures "\n")
+      (cond-> (str sym " " signatures "\n")
         (seq doc) (str doc "\n")
         (seq tags) (str "\n----\n" "lsp: " tags)))))
 

--- a/test/clojure_lsp/handlers_test.clj
+++ b/test/clojure_lsp/handlers_test.clj
@@ -14,35 +14,69 @@
      Position)))
 
 (deftest hover
-  (testing "plain text"
-    (reset! db/db {:file-envs {"file://a.clj" (parser/find-usages (str "(ns a)\n"
-                                                                       "(defn foo [x] x)\n"
-                                                                       "(foo 1)") :clj {})}})
-    (is (= {:range    {:start {:line      2
-                               :character 1}
-                       :end   {:line 2 :character 4}}
-            :contents ["a/foo [x]\n\n----\nlsp: :declare :public"]}
-           (handlers/hover "file://a.clj" 3 3))))
-  (testing "markdown content with function args"
-    (reset! db/db {:client-capabilities {:text-document {:hover {:content-format ["markdown"]}}}
-                   :file-envs           {"file://a.clj" (parser/find-usages (str "(ns a)\n"
-                                                                                 "(defn foo [x] x)\n"
-                                                                                 "(foo 1)") :clj {})}})
-    (is (= {:range    {:start {:line 2 :character 1}
-                       :end   {:line 2 :character 4}}
-            :contents {:kind "markdown"
-                       :value "```clojure\na/foo [x]\n```\n\n----\nlsp: :declare :public"}}
-           (handlers/hover "file://a.clj" 3 3))))
-  (testing "markdown content with no function args"
-    (reset! db/db {:client-capabilities {:text-document {:hover {:content-format ["markdown"]}}}
-                   :file-envs           {"file://a.clj" (parser/find-usages (str "(ns a)\n"
-                                                                                 "(defn foo [] 1)\n"
-                                                                                 "(foo)") :clj {})}})
-    (is (= {:range    {:start {:line 2 :character 1}
-                       :end   {:line 2 :character 4}}
-            :contents {:kind "markdown"
-                       :value "```clojure\na/foo []\n```\n\n----\nlsp: :declare :public"}}
-           (handlers/hover "file://a.clj" 3 2)))))
+  (testing "with show-docs-arity-on-same-line? disabled"
+    (testing "plain text"
+      (reset! db/db {:file-envs {"file://a.clj" (parser/find-usages (str "(ns a)\n"
+                                                                         "(defn foo [x] x)\n"
+                                                                         "(foo 1)") :clj {})}})
+      (is (= {:range    {:start {:line      2
+                                 :character 1}
+                         :end   {:line 2 :character 4}}
+              :contents ["a/foo \n[x]\n\n----\nlsp: :declare :public"]}
+             (handlers/hover "file://a.clj" 3 3))))
+    (testing "markdown content with function args"
+      (reset! db/db {:client-capabilities {:text-document {:hover {:content-format ["markdown"]}}}
+                     :file-envs           {"file://a.clj" (parser/find-usages (str "(ns a)\n"
+                                                                                   "(defn foo [x] x)\n"
+                                                                                   "(foo 1)") :clj {})}})
+      (is (= {:range    {:start {:line 2 :character 1}
+                         :end   {:line 2 :character 4}}
+              :contents {:kind  "markdown"
+                         :value "```clojure\na/foo \n```\n```clojure\n[x]\n```\n\n----\nlsp: :declare :public"}}
+             (handlers/hover "file://a.clj" 3 3))))
+    (testing "markdown content with no function args"
+      (reset! db/db {:client-capabilities {:text-document {:hover {:content-format ["markdown"]}}}
+                     :file-envs           {"file://a.clj" (parser/find-usages (str "(ns a)\n"
+                                                                                   "(defn foo [] 1)\n"
+                                                                                   "(foo)") :clj {})}})
+      (is (= {:range    {:start {:line 2 :character 1}
+                         :end   {:line 2 :character 4}}
+              :contents {:kind  "markdown"
+                         :value "```clojure\na/foo \n```\n```clojure\n[]\n```\n\n----\nlsp: :declare :public"}}
+             (handlers/hover "file://a.clj" 3 2)))))
+  (testing "with show-docs-arity-on-same-line? enabled"
+    (testing "plain text"
+      (reset! db/db {:settings  {"show-docs-arity-on-same-line?" true}
+                     :file-envs {"file://a.clj" (parser/find-usages (str "(ns a)\n"
+                                                                         "(defn foo [x] x)\n"
+                                                                         "(foo 1)") :clj {})}})
+      (is (= {:range    {:start {:line      2
+                                 :character 1}
+                         :end   {:line 2 :character 4}}
+              :contents ["a/foo [x]\n\n----\nlsp: :declare :public"]}
+             (handlers/hover "file://a.clj" 3 3))))
+    (testing "markdown content with function args"
+      (reset! db/db {:settings            {"show-docs-arity-on-same-line?" true}
+                     :client-capabilities {:text-document {:hover {:content-format ["markdown"]}}}
+                     :file-envs           {"file://a.clj" (parser/find-usages (str "(ns a)\n"
+                                                                                   "(defn foo [x] x)\n"
+                                                                                   "(foo 1)") :clj {})}})
+      (is (= {:range    {:start {:line 2 :character 1}
+                         :end   {:line 2 :character 4}}
+              :contents {:kind  "markdown"
+                         :value "```clojure\na/foo [x]\n```\n\n----\nlsp: :declare :public"}}
+             (handlers/hover "file://a.clj" 3 3))))
+    (testing "markdown content with no function args"
+      (reset! db/db {:settings            {"show-docs-arity-on-same-line?" true}
+                     :client-capabilities {:text-document {:hover {:content-format ["markdown"]}}}
+                     :file-envs           {"file://a.clj" (parser/find-usages (str "(ns a)\n"
+                                                                                   "(defn foo [] 1)\n"
+                                                                                   "(foo)") :clj {})}})
+      (is (= {:range    {:start {:line 2 :character 1}
+                         :end   {:line 2 :character 4}}
+              :contents {:kind  "markdown"
+                         :value "```clojure\na/foo []\n```\n\n----\nlsp: :declare :public"}}
+             (handlers/hover "file://a.clj" 3 2))))))
 
 (deftest test-rename
   (reset! db/db {:file-envs


### PR DESCRIPTION
* Use markdown Clojure for color syntax.
* Add arity on the right side of function instead of on another markdown line

Before: 
![image](https://user-images.githubusercontent.com/7820865/85210659-3ea7e900-b318-11ea-9b9a-007d08c0d3a0.png)

After:
![Screenshot from 2020-06-20 17-02-10](https://user-images.githubusercontent.com/7820865/85210623-e7097d80-b317-11ea-9003-ec428c53c38c.png)

