### PR TITLE
formatting: return empty array instead of null when no changes

### DIFF
--- a/src/clojure_lsp/handlers.clj
+++ b/src/clojure_lsp/handlers.clj
@@ -513,7 +513,8 @@
         new-text (cljfmt/reformat-string
                    text
                    (get-in @db/db [:settings "cljfmt"]))]
-    (when-not (= new-text text)
+    (if (= new-text text)
+      []
       [{:range (shared/->range {:row 1 :col 1 :end-row 1000000 :end-col 1000000})
         :new-text new-text}])))
 

--- a/test/clojure_lsp/handlers_test.clj
+++ b/test/clojure_lsp/handlers_test.clj
@@ -336,6 +336,17 @@
              (is (= data "user/alpha"))
              (is (string/includes? documentation data)))))))
 
+(deftest test-formatting
+  (reset! db/db {:documents {"file://a.clj" {:text "(a  )\n(b c d)"}}})
+  (is (= "(a)\n(b c d)"
+         (:new-text (first (handlers/formatting "file://a.clj"))))))
+
+(deftest test-formatting-noop
+  (reset! db/db {:documents {"file://a.clj" {:text "(a)\n(b c d)"}}})
+  (let [r (handlers/formatting "file://a.clj")]
+    (is (empty? r))
+    (is (vector? r))))
+
 (deftest test-range-formatting
   (reset! db/db {:documents {"file://a.clj" {:text "(a  )\n(b c d)"}}})
   (is (= [{:range {:start {:line 0 :character 0}


### PR DESCRIPTION
It seems like the expectation is that edits is `TextEdit[]`, that is a non-nil. This change makes it return an empty array if there are no formatting changes.