### PR TITLE
Add code lens support

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ Bellow are all the currently supported LSP capabilities and their implementation
 | textDocument/documentHighlight      | √    |                                               |
 | textDocument/documentSymbol         | √    |                                               |
 | textDocument/codeAction             | √    |                                               |
-| textDocument/codeLens               |      |                                               |
+| textDocument/codeLens               | √    |                                               |
 | codeLens/resolve                    |      |                                               |
 | textDocument/documentLink           |      |                                               |
 | documentLink/resolve                |      |                                               |

--- a/src/clojure_lsp/handlers.clj
+++ b/src/clojure_lsp/handlers.clj
@@ -273,12 +273,13 @@
 (defn reference-usages [doc-id line column]
   (let [file-envs (:file-envs @db/db)
         local-env (get file-envs doc-id)
-        cursor-sym (:sym (find-reference-under-cursor line column local-env (shared/uri->file-type doc-id)))]
+        {cursor-sym :sym} (find-reference-under-cursor line column local-env (shared/uri->file-type doc-id))]
     (log/warn "references" doc-id line column cursor-sym)
     (into []
           (for [[uri usages] (:file-envs @db/db)
-                {:keys [sym] :as usage} usages
-                :when (= sym cursor-sym)]
+                {:keys [sym tags] :as usage} usages
+                :when (and (= sym cursor-sym)
+                           (not (contains? tags :declare)))]
             {:uri uri
              :usage usage}))))
 
@@ -598,3 +599,19 @@
              :command {:title     "Clean namespace"
                        :command   "clean-ns"
                        :arguments [doc-id line character]}}))))
+(defn code-lens
+  [doc-id]
+  (let [db @db/db
+        usages (get-in db [:file-envs doc-id])]
+
+    (->> usages
+         (filter (fn [{:keys [tags]}]
+                   (and (contains? tags :declare)
+                        (not (contains? tags :alias))
+                        (not (contains? tags :param)))))
+         (map (fn [usage]
+                {:range   (shared/->range usage)
+                 :command {:title (-> doc-id
+                                      (reference-usages (:row usage) (:col usage))
+                                      count
+                                      (str " references"))}})))))

--- a/src/clojure_lsp/interop.clj
+++ b/src/clojure_lsp/interop.clj
@@ -9,6 +9,7 @@
     (org.eclipse.lsp4j
       CodeAction
       CodeActionKind
+      CodeLens
       Command
       CompletionItem
       CompletionItemKind
@@ -196,6 +197,15 @@
                                             (.setCommand (:command %1))))))
 
 (s/def ::code-actions (s/coll-of ::code-action))
+
+(s/def ::code-lens (s/and (s/keys :req-un [::range]
+                                  :opt-un [::command ::data])
+                          (s/conformer #(doto (CodeLens.)
+                                          (.setRange (:range %1))
+                                          (.setCommand (:command %1))
+                                          (.setData (:data %1))))))
+
+(s/def ::code-lenses (s/coll-of ::code-lens))
 
 (defn debeaner [inst]
   (when inst

--- a/src/clojure_lsp/main.clj
+++ b/src/clojure_lsp/main.clj
@@ -14,6 +14,8 @@
       ApplyWorkspaceEditParams
       CodeActionParams
       CodeAction
+      CodeLensParams
+      CodeLensOptions
       Command
       CompletionItem
       CompletionItemKind
@@ -247,6 +249,15 @@
                  (catch Exception e
                    (log/error e)))))))))
 
+  (^CompletableFuture codeLens [_ ^CodeLensParams params]
+   (go :codeLens
+       (CompletableFuture/supplyAsync
+         (reify Supplier
+           (get [_this]
+             (end
+               (let [doc-id          (interop/document->decoded-uri (.getTextDocument params))]
+                 (interop/conform-or-log ::interop/code-lenses (#'handlers/code-lens doc-id)))))))))
+
   (^CompletableFuture definition [this ^DefinitionParams params]
     (go :definition
         (CompletableFuture/supplyAsync
@@ -366,6 +377,7 @@
                 (InitializeResult. (doto (ServerCapabilities.)
                                      (.setHoverProvider true)
                                      (.setCodeActionProvider true)
+                                     (.setCodeLensProvider (CodeLensOptions. true))
                                      (.setReferencesProvider true)
                                      (.setRenameProvider true)
                                      (.setDefinitionProvider true)


### PR DESCRIPTION
- Add support for `textDocument/codeLens`
  - Add reference code lens showing how many references a function/variable has.
- Fix `references` finding the symbol at cursor which was causing code lens always showing 1 reference at least (the symbol itself)

![image](https://user-images.githubusercontent.com/7820865/89317526-d9a01c80-d653-11ea-88e3-e83754f0e74b.png)
