### PR TITLE
Migrate most linters to use clj-kondo

### DIFF
--- a/src/clojure_lsp/crawler.clj
+++ b/src/clojure_lsp/crawler.clj
@@ -168,7 +168,6 @@
                       :config {:linters (into {} (map #(hash-map % {:level :off})
                                                       #{:invalid-arity
                                                         :unused-bindings
-                                                        :unresolved-namespace
                                                         :unused-namespace}))}})
 
 (defn- run-kondo!

--- a/test/clojure_lsp/handlers_test.clj
+++ b/test/clojure_lsp/handlers_test.clj
@@ -261,11 +261,11 @@
                      {"file://a.clj" (parser/find-usages "(ns a) (def bar ::bar)" :clj {})
                       "file://b.clj" (parser/find-usages code-b :clj {})}})
       (let [usages (crawler/find-diagnostics "file://b.clj" code-b (get-in @db/db [:file-envs "file://b.clj"]))]
-        (is (= ["Unused alias: c"
-                "Unused namespace: b"
+        (is (= ["Unused namespace: b"
                 "Unused declaration: x"
                 "Unused declaration: y"
                 "Unknown forward declaration: wat"
+                "namespace c is required but never used"
                 "Unresolved namespace f. Are you missing a require?"]
                (map :message usages)))))))
 

--- a/test/clojure_lsp/handlers_test.clj
+++ b/test/clojure_lsp/handlers_test.clj
@@ -278,7 +278,8 @@
                 "Unused namespace: b"
                 "Unused declaration: x"
                 "Unused declaration: y"
-                "Unknown forward declaration: wat"]
+                "Unknown forward declaration: wat"
+                "Unresolved namespace f. Are you missing a require?"]
                (map :message usages)))))))
 
 (deftest test-completion

--- a/test/clojure_lsp/handlers_test.clj
+++ b/test/clojure_lsp/handlers_test.clj
@@ -158,7 +158,7 @@
                   (foo 1 ['a 'b])
                   (foo 1 2 3 {:k 1 :v 2})"]
         (reset! db/db {:file-envs {"file://a.clj" (parser/find-usages code :clj {})}})
-        (let [usages (crawler/find-diagnostics #{} "file://a.clj" code (get-in @db/db [:file-envs "file://a.clj"]))]
+        (let [usages (crawler/find-diagnostics "file://a.clj" code (get-in @db/db [:file-envs "file://a.clj"]))]
           (is (= ["No overload for 'foo' with 3 arguments"
                   "No overload for 'baz' with 1 argument"
                   "No overload for 'bar' with 0 arguments"
@@ -189,7 +189,7 @@
                     (foo 1)
                     (bar))"]
         (reset! db/db {:file-envs {"file://a.clj" (parser/find-usages code :clj {})}})
-        (let [usages (crawler/find-diagnostics #{} "file://a.clj" code (get-in @db/db [:file-envs "file://a.clj"]))]
+        (let [usages (crawler/find-diagnostics "file://a.clj" code (get-in @db/db [:file-envs "file://a.clj"]))]
           (is (= ["No overload for 'foo' with 2 arguments"
                   "No overload for 'bar' with 1 argument"
                   "No overload for 'bar' with 1 argument"
@@ -205,7 +205,7 @@
                   (bar :a)
                   (bar :a :b)"]
         (reset! db/db {:file-envs {"file://a.clj" (parser/find-usages code :clj {})}})
-        (let [usages (crawler/find-diagnostics #{} "file://a.clj" code (get-in @db/db [:file-envs "file://a.clj"]))]
+        (let [usages (crawler/find-diagnostics "file://a.clj" code (get-in @db/db [:file-envs "file://a.clj"]))]
           (is (= ["No overload for 'foo' with 2 arguments"]
                  (map :message usages))))))
     (testing "for meta arglists"
@@ -218,7 +218,7 @@
                   (foo)
                   (foo (foo :a :b))"]
         (reset! db/db {:file-envs {"file://a.clj" (parser/find-usages code :clj {})}})
-        (let [usages (crawler/find-diagnostics #{} "file://a.clj" code (get-in @db/db [:file-envs "file://a.clj"]))]
+        (let [usages (crawler/find-diagnostics "file://a.clj" code (get-in @db/db [:file-envs "file://a.clj"]))]
           (is (= ["No overload for 'foo' with 0 arguments"
                   "No overload for 'foo' with 2 arguments"]
                  (map :message usages))))))
@@ -231,7 +231,7 @@
                   (foo 1 2)
                   (foo 1)"]
         (reset! db/db {:file-envs {"file://a.clj" (parser/find-usages code :clj {})}})
-        (let [usages (crawler/find-diagnostics #{} "file://a.clj" code (get-in @db/db [:file-envs "file://a.clj"]))]
+        (let [usages (crawler/find-diagnostics "file://a.clj" code (get-in @db/db [:file-envs "file://a.clj"]))]
           (is (= ["Unused namespace: user"
                   "No overload for 'foo' with 0 arguments"
                   "No overload for 'foo' with 1 argument"]
@@ -248,7 +248,7 @@
                                                                              [:any] [:param]]}
                                                            :bound-elements]})
             _ (reset! db/db {:file-envs {"file://a.clj" usages}})
-            diagnostics (crawler/find-diagnostics #{} "file://a.clj" code (get-in @db/db [:file-envs "file://a.clj"]))]
+            diagnostics (crawler/find-diagnostics "file://a.clj" code (get-in @db/db [:file-envs "file://a.clj"]))]
         (is (= [] (mapv :message (drop 1 diagnostics)))))))
   (testing "unused symbols"
     (let [code-b "(ns b
@@ -273,9 +273,8 @@
       (reset! db/db {:file-envs
                      {"file://a.clj" (parser/find-usages "(ns a) (def bar ::bar)" :clj {})
                       "file://b.clj" (parser/find-usages code-b :clj {})}})
-      (let [usages (crawler/find-diagnostics #{} "file://b.clj" code-b (get-in @db/db [:file-envs "file://b.clj"]))]
-        (is (= ["Unknown namespace: f"
-                "Unused alias: c"
+      (let [usages (crawler/find-diagnostics "file://b.clj" code-b (get-in @db/db [:file-envs "file://b.clj"]))]
+        (is (= ["Unused alias: c"
                 "Unused namespace: b"
                 "Unused declaration: x"
                 "Unused declaration: y"


### PR DESCRIPTION
With this PR we now use all default linters from clj-kondo letting `clojure-lsp` only take care of `unused references` warnings, and `unknown forward declaration` (not supported by kondo).

Besides the tests, I tested each linter manually to check if we would break some current linter.