### PR TITLE
Provide missing exists?, this-as for Clojurescript

### DIFF
--- a/src/clojure_lsp/clojure_core.clj
+++ b/src/clojure_lsp/clojure_core.clj
@@ -1186,6 +1186,7 @@
      t_cljs$core11184
      t_cljs$core9576
      tap>
+     this-as
      transformer-iterator
      truth_
      type->str

--- a/src/clojure_lsp/clojure_core.clj
+++ b/src/clojure_lsp/clojure_core.clj
@@ -346,7 +346,6 @@
      every?
      ex-data
      ex-info
-     exists?
      extend
      extend-protocol
      extend-type
@@ -1118,6 +1117,7 @@
      es6-set-entries-iterator
      ex-cause
      ex-message
+     exists?
      find-macros-ns
      find-ns-obj
      gensym_counter

--- a/src/clojure_lsp/clojure_core.clj
+++ b/src/clojure_lsp/clojure_core.clj
@@ -346,6 +346,7 @@
      every?
      ex-data
      ex-info
+     exists?
      extend
      extend-protocol
      extend-type


### PR DESCRIPTION
@snoe It seems that `exists?` symbol is missing for clojurescript which triggers bunch of errors on flycheck.
It's my first time I read the clojure-lsp source code, but it seems that one line change should resolve the issue. 