### PR TITLE
Add command for retrieve server-info

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Bellow are all the currently supported LSP capabilities and their implementation
 | exit                                | √    |                                               |
 | $/cancelRequest                     |      |                                               |
 | $/progress                          |      |                                               |
-| window/showMessage                  |      |                                               |
+| window/showMessage                  | √    |                                               |
 | window/showMessageRequest           |      |                                               |
 | window/logMessage                   |      |                                               |
 | window/workDoneProgress/create      |      |                                               |

--- a/src/clojure_lsp/crawler.clj
+++ b/src/clojure_lsp/crawler.clj
@@ -296,7 +296,7 @@
                   (str (get-in (run-kondo! source-paths kondo-user-config) [:summary :duration]) "ms"))
         (async/<!! crawler-output-chan)))))
 
-(defn find-project-settings [project-root]
+(defn find-raw-project-settings [project-root]
   (let [config-path (Paths/get ".lsp" (into-array ["config.edn"]))]
     (loop [dir (uri->path project-root)]
       (let [full-config-path (.resolve dir config-path)
@@ -304,10 +304,14 @@
             parent-dir (.getParent dir)]
         (cond
           (.exists file)
-          (edn/read-string {:readers {'re re-pattern}} (slurp file))
+          (slurp file)
 
           parent-dir
           (recur parent-dir)
 
           :else
-          {})))))
+          "{}")))))
+
+(defn find-project-settings [project-root]
+  (->> (find-raw-project-settings project-root)
+       (edn/read-string {:readers {'re re-pattern}})))

--- a/src/clojure_lsp/interop.clj
+++ b/src/clojure_lsp/interop.clj
@@ -170,6 +170,11 @@
                               :opt-un [:command/arguments])
                       (s/conformer #(Command. (:title %1) (:command %1)(:arguments %1)))))
 
+(s/def ::server-info (s/keys :req-un [:server-info/port
+                                      :server-info/project-settings
+                                      :server-info/client-settings
+                                      :server-info/project-root]))
+
 (s/def :code-action/title string?)
 
 (def code-action-kind

--- a/src/clojure_lsp/interop.clj
+++ b/src/clojure_lsp/interop.clj
@@ -21,6 +21,8 @@
       Location
       MarkedString
       MarkupContent
+      MessageParams
+      MessageType
       Position
       PublishDiagnosticsParams
       Range
@@ -170,10 +172,21 @@
                               :opt-un [:command/arguments])
                       (s/conformer #(Command. (:title %1) (:command %1)(:arguments %1)))))
 
-(s/def ::server-info (s/keys :req-un [:server-info/port
-                                      :server-info/project-settings
-                                      :server-info/client-settings
-                                      :server-info/project-root]))
+(def show-message-type-enum
+  {:error MessageType/Error
+   :warning MessageType/Warning
+   :info MessageType/Info
+   :log MessageType/Log})
+
+(s/def :show-message/type (s/and keyword?
+                                 show-message-type-enum
+                                 (s/conformer #(get show-message-type-enum %))))
+
+(s/def :show-message/message string?)
+
+(s/def ::show-message (s/and (s/keys :req-un [:show-message/type
+                                              :show-message/message])
+                             (s/conformer #(MessageParams. (:type %) (:message %)))))
 
 (s/def :code-action/title string?)
 

--- a/src/clojure_lsp/main.clj
+++ b/src/clojure_lsp/main.clj
@@ -14,17 +14,12 @@
    (org.eclipse.lsp4j
      ApplyWorkspaceEditParams
      CodeActionParams
-     CodeAction
      CodeLens
      CodeLensParams
      CodeLensOptions
-     Command
      CompletionItem
-     CompletionItemKind
      CompletionOptions
      CompletionParams
-     ConfigurationItem
-     ConfigurationParams
      DefinitionParams
      DidChangeConfigurationParams
      DidChangeTextDocumentParams
@@ -37,7 +32,6 @@
      DocumentHighlightParams
      DocumentRangeFormattingParams
      DocumentSymbolParams
-     DocumentSymbol
      ExecuteCommandOptions
      ExecuteCommandParams
      FileSystemWatcher
@@ -53,7 +47,6 @@
      SaveOptions
      ServerCapabilities
      SignatureHelp
-     SignatureHelpOptions
      SignatureHelpParams
      SignatureInformation
      TextDocumentContentChangeEvent
@@ -61,7 +54,6 @@
      TextDocumentSyncOptions
      WorkspaceSymbolParams)
    (org.eclipse.lsp4j.launch LSPLauncher)
-   (org.eclipse.lsp4j.jsonrpc.services JsonSegment JsonRequest)
    (java.util.concurrent CompletableFuture)
    (java.util.function Supplier))
   (:gen-class))
@@ -315,24 +307,18 @@
 
 (deftype LSPWorkspaceService []
   WorkspaceService
+
   (^CompletableFuture executeCommand [_ ^ExecuteCommandParams params]
-    (go :executeCommand
-        (let [[doc-id line col & args] (map interop/json->clj (.getArguments params))
-              command (.getCommand params)]
-          (future
-            (end
-              (try
-                (when-let [result (#'handlers/refactor doc-id
-                                                       (inc (int line))
-                                                       (inc (int col))
-                                                       command
-                                                       args)]
-                  (.get (.applyEdit (:client @db/db)
-                                    (ApplyWorkspaceEditParams.
-                                      (interop/conform-or-log ::interop/workspace-edit result)))))
-                (catch Exception e
-                  (log/error e)))))))
-    (CompletableFuture/completedFuture 0))
+   (go :executeCommand
+       (CompletableFuture/supplyAsync
+         (reify Supplier
+           (get [this]
+             (end
+               (let [command (.getCommand params)
+                     args (.getArguments params)]
+                 (log/info "Executing command" command "with args" args)
+                 (#'handlers/execute-command command args))))))))
+
   (^void didChangeConfiguration [_ ^DidChangeConfigurationParams params]
     (log/warn params))
 
@@ -430,11 +416,14 @@
       (LSPWorkspaceService.))))
 
 (defn- run []
-  (log/info "Server started")
+  (log/info "Starting server...")
   (let [launcher (LSPLauncher/createServerLauncher server System/in System/out)
-        repl-server (nrepl.server/start-server)]
-    (log/info "====== LSP nrepl server started on port" (:port repl-server))
-    (swap! db/db assoc :client ^LanguageClient (.getRemoteProxy launcher))
+        repl-server (nrepl.server/start-server)
+        port (:port repl-server)]
+    (log/info "====== LSP nrepl server started on port" port)
+    (swap! db/db assoc
+           :client ^LanguageClient (.getRemoteProxy launcher)
+           :port port)
     (async/go
       (loop [edit (async/<! db/edits-chan)]
         (log/warn "edit applied?" (.get (.applyEdit (:client @db/db) (ApplyWorkspaceEditParams. (interop/conform-or-log ::interop/workspace-edit edit)))))


### PR DESCRIPTION
* adds a new command: `server-info` which returns the port, project-root and config.