### PR TITLE
Add support for renaming files

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ Bellow are all the currently supported LSP capabilities and their implementation
 | workspace/didChangeWatchedFiles     | √    |                                               |
 | workspace/symbol                    | √    |                                               |
 | workspace/executeCommand            | √    | See [Extra capabilities](#extra-capabilities) |
-| workspace/applyEdit                 | √    |                                               |
+| workspace/applyEdit                 | √    | TextDocumentEdit and RenameFile only          |
 | textDocument/didOpen                | √    |                                               |
 | textDocument/didChange              | √    |                                               |
 | textDocument/willSave               |      |                                               |

--- a/src/clojure_lsp/handlers.clj
+++ b/src/clojure_lsp/handlers.clj
@@ -63,6 +63,26 @@
                              (subs (count source-path))
                              (string/replace #"/" ".")
                              (string/replace #"_" "-")))))))))
+
+(defn ^:private source-path-from-uri [uri]
+  (let [project-root (:project-root @db/db)
+        source-paths (get-in @db/db [:settings :source-paths])]
+    (->> source-paths
+         (some (fn [source-path]
+                 (when (string/starts-with? uri (str project-root "/" source-path "/"))
+                   source-path))))))
+
+(defn ^:private namespace->uri [namespace project-root source-path file-type]
+  (str project-root
+       "/"
+       source-path
+       "/"
+       (-> namespace
+           (string/replace "." "/")
+           (string/replace "-" "_"))
+       "."
+       (name file-type)))
+
 (defn- client-changes [changes]
   (if (get-in @db/db [:client-capabilities :workspace :workspace-edit :document-changes])
     {:document-changes changes}
@@ -316,8 +336,11 @@
 
 (defn rename [doc-id line column new-name]
   (let [file-envs (:file-envs @db/db)
+        project-root (:project-root @db/db)
         local-env (get file-envs doc-id)
-        {cursor-sym :sym cursor-str :str tags :tags :as cursor-usage} (find-reference-under-cursor line column local-env (shared/uri->file-type doc-id))]
+        file-type (shared/uri->file-type doc-id)
+        source-path (source-path-from-uri doc-id)
+        {cursor-sym :sym cursor-str :str tags :tags :as cursor-usage} (find-reference-under-cursor line column local-env file-type)]
     (when (and cursor-usage (not (simple-keyword? cursor-sym)) (not (contains? tags :norename)))
       (let [[_ cursor-ns cursor-name] (parser/ident-split cursor-str)
             replacement (if cursor-ns
@@ -332,7 +355,15 @@
                              (map (fn [[text-document edits]]
                                     {:text-document text-document
                                      :edits edits})))]
-        (client-changes doc-changes)))))
+        (if (and (contains? tags :ns)
+                 (not= (compare cursor-name replacement) 0)
+                 (get-in @db/db [:client-capabilities :workspace :workspace-edit :document-changes]))
+          (let [new-uri (namespace->uri replacement project-root source-path file-type)]
+            (client-changes (concat doc-changes
+                                    [{:kind "rename"
+                                      :old-uri doc-id
+                                      :new-uri new-uri}])))
+          (client-changes doc-changes))))))
 
 (defn definition-usage [doc-id line column]
   (let [file-envs (:file-envs @db/db)

--- a/src/clojure_lsp/handlers.clj
+++ b/src/clojure_lsp/handlers.clj
@@ -303,6 +303,11 @@
           {:uri uri :range (shared/->range usage)})
         (reference-usages doc-id line column)))
 
+(defn did-close [uri]
+  (swap! db/db #(-> %
+                    (update :documents dissoc uri)
+                    (update :file-envs dissoc uri))))
+
 (defn did-change [uri text version]
   ;; Ensure we are only accepting newer changes
   (loop [state-db @db/db]

--- a/src/clojure_lsp/main.clj
+++ b/src/clojure_lsp/main.clj
@@ -7,7 +7,8 @@
    [clojure.core.async :as async]
    [clojure.tools.logging :as log]
    [nrepl.server :as nrepl.server]
-   [trptcolin.versioneer.core :as version])
+   [trptcolin.versioneer.core :as version]
+   [clojure.spec.alpha :as s])
   (:import
    (clojure_lsp ClojureExtensions)
    (org.eclipse.lsp4j.services LanguageServer TextDocumentService WorkspaceService LanguageClient)
@@ -179,8 +180,9 @@
                         pos (.getPosition params)
                         line (inc (.getLine pos))
                         column (inc (.getCharacter pos))
-                        new-name (.getNewName params)]
-                    (interop/conform-or-log ::interop/workspace-edit (#'handlers/rename doc-id line column new-name)))
+                        new-name (.getNewName params)
+                        edit (#'handlers/rename doc-id line column new-name)]
+                    (interop/conform-or-log ::interop/workspace-edit edit))
                   (catch Exception e
                     (log/error e)))))))))
 

--- a/src/clojure_lsp/main.clj
+++ b/src/clojure_lsp/main.clj
@@ -124,7 +124,9 @@
   (^void didClose [_ ^DidCloseTextDocumentParams params]
     (log/warn "DidCloseTextDocumentParams")
     (go :didClose
-        (end (swap! db/db update :documents dissoc (interop/document->decoded-uri (.getTextDocument params))))))
+        (end (-> (.getTextDocument params)
+                 interop/document->decoded-uri
+                 handlers/did-close))))
 
   (^CompletableFuture references [this ^ReferenceParams params]
     (go :references

--- a/test/clojure_lsp/handlers_test.clj
+++ b/test/clojure_lsp/handlers_test.clj
@@ -13,6 +13,17 @@
       Range
       Position)))
 
+(deftest did-close
+  (reset! db/db {:documents {"file://a.clj" {:text "(ns a)"}
+                             "file://b.clj" {:text "(ns b)"}}
+                 :file-envs {"file://a.clj" (parser/find-usages "(ns a)" :clj {})
+                             "file://b.clj" (parser/find-usages "(ns b)" :clj {})}})
+  (testing "should remove references to file"
+    (handlers/did-close "file://a.clj")
+    (is (= {:documents {"file://b.clj" {:text "(ns b)"}}
+            :file-envs {"file://b.clj" (parser/find-usages "(ns b)" :clj {})}}
+           @db/db))))
+
 (deftest hover
   (testing "with show-docs-arity-on-same-line? disabled"
     (testing "plain text"


### PR DESCRIPTION
With that after we call `textDocument/rename` on a namespace symbol, we will send a `RenameFile` to client too