### PR TITLE
Add doc-id, row, and col as arguments to code-lens-references command in codeLens/resolve response

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,5 @@
 /node_modules
 /test.clj
 /.clj-kondo/.cache
+/.clj-kondo/cache
+/.calva/output-window

--- a/src/clojure_lsp/handlers.clj
+++ b/src/clojure_lsp/handlers.clj
@@ -661,4 +661,4 @@
                           count
                           (str " references"))
              :command "code-lens-references"
-             :arguments {:range range}}})
+             :arguments [doc-id row col]}})

--- a/src/clojure_lsp/handlers.clj
+++ b/src/clojure_lsp/handlers.clj
@@ -660,4 +660,5 @@
                           (reference-usages row col)
                           count
                           (str " references"))
-             :command "code-lens-references"}})
+             :command "code-lens-references"
+             :arguments {:range range}}})

--- a/test/clojure_lsp/handlers_test.clj
+++ b/test/clojure_lsp/handlers_test.clj
@@ -502,7 +502,11 @@
                           :end   {:line      1
                                   :character 12}}
                 :command {:title   "0 references"
-                          :command "code-lens-references"}}
+                          :command "code-lens-references"
+                          :arguments {:range {:start {:line      1
+                                                      :character 5}
+                                              :end   {:line      1
+                                                      :character 12}}}}}
                (handlers/code-lens-resolve {:start {:line 1 :character 5} :end {:line 1 :character 12}}
                                            ["file://a.clj" 1 5]))))
       (testing "some lens"
@@ -512,6 +516,10 @@
                           :end   {:line      2
                                   :character 11}}
                 :command {:title   "1 references"
-                          :command "code-lens-references"}}
+                          :command "code-lens-references"
+                          :arguments {:range {:start {:line      2
+                                                      :character 7}
+                                              :end   {:line      2
+                                                      :character 11}}}}}
                (handlers/code-lens-resolve {:start {:line 2 :character 7} :end {:line 2 :character 11}}
                                            ["file://a.clj" 3 8])))))))

--- a/test/clojure_lsp/handlers_test.clj
+++ b/test/clojure_lsp/handlers_test.clj
@@ -503,10 +503,7 @@
                                   :character 12}}
                 :command {:title   "0 references"
                           :command "code-lens-references"
-                          :arguments {:range {:start {:line      1
-                                                      :character 5}
-                                              :end   {:line      1
-                                                      :character 12}}}}}
+                          :arguments ["file://a.clj" 1 5]}}
                (handlers/code-lens-resolve {:start {:line 1 :character 5} :end {:line 1 :character 12}}
                                            ["file://a.clj" 1 5]))))
       (testing "some lens"
@@ -517,9 +514,6 @@
                                   :character 11}}
                 :command {:title   "1 references"
                           :command "code-lens-references"
-                          :arguments {:range {:start {:line      2
-                                                      :character 7}
-                                              :end   {:line      2
-                                                      :character 11}}}}}
+                          :arguments ["file://a.clj" 3 8]}}
                (handlers/code-lens-resolve {:start {:line 2 :character 7} :end {:line 2 :character 11}}
                                            ["file://a.clj" 3 8])))))))


### PR DESCRIPTION
I made this change so that peeking code references by clicking the code lens would work in VS Code. This works well with the vscode-languageclient, and since it's additive I don't think it would cause any issues with other clients.

Updated related tests.

Fixes #196