### PR TITLE
Prevent negative numbers in ranges

### DIFF
--- a/src/clojure_lsp/shared.clj
+++ b/src/clojure_lsp/shared.clj
@@ -14,8 +14,8 @@
     :else :unknown))
 
 (defn ->range [{:keys [row end-row col end-col]}]
-  {:start {:line (dec row) :character (dec col)}
-   :end {:line (dec end-row) :character (dec end-col)}})
+  {:start {:line (max 0 (dec row)) :character (max 0 (dec col))}
+   :end {:line (max 0 (dec end-row)) :character (max 0 (dec end-col))}})
 
 (defn range->clj [^Range range]
   {:start {:line      (.getLine (.getStart range))

--- a/test/clojure_lsp/shared_test.clj
+++ b/test/clojure_lsp/shared_test.clj
@@ -1,0 +1,17 @@
+(ns clojure-lsp.shared-test
+  (:require [clojure-lsp.shared :as shared]
+            [clojure.test :refer [deftest testing is]]))
+
+(deftest ->range-test
+  (testing "should subtract 1 from row and col values"
+    (is (= {:start {:line      1
+                    :character 1}
+            :end   {:line      1
+                    :character 1}}
+           (shared/->range {:row 2 :end-row 2 :col 2 :end-col 2}))))
+  (testing "should not return negative line and character values"
+    (is (= {:start {:line      0
+                    :character 0}
+            :end   {:line      0
+                    :character 0}}
+           (shared/->range {:row 0 :end-row 0 :col 0 :end-col 0})))))


### PR DESCRIPTION
Also added tests for `clojure-lsp.shared/->range`, one of which covers this case.

Fixes #198 