### PR TITLE
Fix duplicated usages/references for cljc files

### DIFF
--- a/src/clojure_lsp/crawler.clj
+++ b/src/clojure_lsp/crawler.clj
@@ -203,7 +203,7 @@
                       [uri (safe-find-references uri text false true)])))
              (remove (comp nil? second)))
         output-chan (async/chan 5)]
-    (async/pipeline-blocking 5 output-chan xf (async/to-chan jars) true (fn [e] (log/warn e "hello")))
+    (async/pipeline-blocking 5 output-chan xf (async/to-chan! jars) true (fn [e] (log/warn e "hello")))
     (async/<!! (async/into {} output-chan))))
 
 (defn crawl-source-dirs [dirs]
@@ -219,7 +219,7 @@
                                   (safe-find-references uri (slurp uri) false false))))
             (remove (comp nil? second)))
         output-chan (async/chan)]
-    (async/pipeline-blocking 5 output-chan xf (async/to-chan dirs) true (fn [e] (log/warn e "hello")))
+    (async/pipeline-blocking 5 output-chan xf (async/to-chan! dirs) true (fn [e] (log/warn e "hello")))
     (async/<!! (async/into {} output-chan))))
 
 (defn lookup-classpath [root-path command-args env]

--- a/src/clojure_lsp/db.clj
+++ b/src/clojure_lsp/db.clj
@@ -11,7 +11,7 @@
 (defonce diagnostics-chan (async/chan 1))
 (defonce edits-chan (async/chan 1))
 
-(def version 2)
+(def version 3)
 
 (defn make-spec [project-root]
   (let [lsp-db (io/file (str project-root) ".lsp" "sqlite.1.db")]


### PR DESCRIPTION
#fix 208

This PR changes how we save usages on db. We now save `file-type` as a set, so instead of 2 usages with `clj` and another with `cljs` file-types, we now persist only one with `#{clj cljs}` as file-type.
This is only applicable for non `norename` tags as we just want to do that for user namespace/alias usages