### PR TITLE
Add basic support for semantic tokens

### DIFF
--- a/.lsp/config.edn
+++ b/.lsp/config.edn
@@ -1,7 +1,8 @@
-{"cljfmt" {:indents {#re ".*" [[:block 0]]
-                     ns [[:inner 0] [:inner 1]]
-                     and [[:inner 1]]
-                     or [[:inner 1]]
-                     are [[:inner 0]]}}
- "clj-kondo" {:linters {:unused-namespace {:exclude [clojure.tools.logging]}}}
- "use-metadata-for-privacy?" true}
+{:cljfmt {:indents {#re ".*" [[:block 0]]
+                    ns [[:inner 0] [:inner 1]]
+                    and [[:inner 1]]
+                    or [[:inner 1]]
+                    are [[:inner 0]]}}
+ :clj-kondo {:linters {:unused-namespace {:exclude [clojure.tools.logging]}}}
+ :semantic-tokens true
+ :use-metadata-for-privacy? true}

--- a/src/clojure_lsp/db.clj
+++ b/src/clojure_lsp/db.clj
@@ -11,10 +11,10 @@
 (defonce diagnostics-chan (async/chan 1))
 (defonce edits-chan (async/chan 1))
 
-(def version 3)
+(def version 4)
 
 (defn make-spec [project-root]
-  (let [lsp-db (io/file (str project-root) ".lsp" "sqlite.1.db")]
+  (let [lsp-db (io/file (str project-root) ".lsp" (str "sqlite." version ".db"))]
     {:dbtype "sqlite"
      :dbname (.getAbsolutePath lsp-db)}))
 

--- a/src/clojure_lsp/handlers.clj
+++ b/src/clojure_lsp/handlers.clj
@@ -670,6 +670,4 @@
   (let [db @db/db
         usages (get-in db [:file-envs doc-id])
         data (semantic-tokens/full usages)]
-    (log/info "======>" usages)
-    (log/info "------>" data)
     {:data data}))

--- a/src/clojure_lsp/handlers.clj
+++ b/src/clojure_lsp/handlers.clj
@@ -1,23 +1,24 @@
 (ns clojure-lsp.handlers
   (:require
-    [cljfmt.core :as cljfmt]
-    [cljfmt.main :as cljfmt.main]
-    [clojure-lsp.clojure-core :as cc]
-    [clojure-lsp.crawler :as crawler]
-    [clojure-lsp.db :as db]
-    [clojure-lsp.interop :as interop]
-    [clojure-lsp.parser :as parser]
-    [clojure-lsp.refactor.transform :as refactor]
-    [clojure-lsp.shared :as shared]
-    [clojure.core.async :as async]
-    [clojure.pprint :as pprint]
-    [clojure.set :as set]
-    [clojure.string :as string]
-    [clojure.tools.logging :as log]
-    [rewrite-clj.node :as n]
-    [rewrite-clj.zip :as z])
+   [cljfmt.core :as cljfmt]
+   [cljfmt.main :as cljfmt.main]
+   [clojure-lsp.clojure-core :as cc]
+   [clojure-lsp.crawler :as crawler]
+   [clojure-lsp.db :as db]
+   [clojure-lsp.interop :as interop]
+   [clojure-lsp.parser :as parser]
+   [clojure-lsp.refactor.transform :as refactor]
+   [clojure-lsp.shared :as shared]
+   [clojure.core.async :as async]
+   [clojure.pprint :as pprint]
+   [clojure.set :as set]
+   [clojure.string :as string]
+   [clojure.tools.logging :as log]
+   [rewrite-clj.node :as n]
+   [rewrite-clj.zip :as z]
+   [clojure-lsp.semantic-tokens :as semantic-tokens])
   (:import
-    [java.net URL JarURLConnection]))
+   [java.net URL JarURLConnection]))
 
 (defn check-bounds [line column {:keys [row end-row col end-col] :as _usage}]
   (cond
@@ -390,7 +391,7 @@
 
 (defn definition [doc-id line column]
   (let [[cursor {:keys [uri usage]}] (definition-usage doc-id line column)]
-    (log/warn "Finding definition" doc-id "row" line "col" column "cursor" (:sym cursor))
+    (log/info "Finding definition" doc-id "row" line "col" column "cursor" (:sym cursor))
     (if (:sym cursor)
       (if usage
         {:uri uri :range (shared/->range usage) :str (:str usage)}
@@ -663,3 +664,12 @@
                           (str " references"))
              :command "code-lens-references"
              :arguments [doc-id row col]}})
+
+(defn semantic-tokens-full
+  [doc-id]
+  (let [db @db/db
+        usages (get-in db [:file-envs doc-id])
+        data (semantic-tokens/full usages)]
+    (log/info "======>" usages)
+    (log/info "------>" data)
+    {:data data}))

--- a/src/clojure_lsp/interop.clj
+++ b/src/clojure_lsp/interop.clj
@@ -397,7 +397,8 @@
         (update :cljfmt kwd-keys)
         (update-in [:cljfmt :indents] clean-symbol-map)
         (update :document-formatting? (fnil identity true))
-        (update :document-range-formatting? (fnil identity true)))))
+        (update :document-range-formatting? (fnil identity true))
+        (update :semantic-tokens? (fnil identity false)))))
 
 (defn document->decoded-uri [document]
   (-> document

--- a/src/clojure_lsp/interop.clj
+++ b/src/clojure_lsp/interop.clj
@@ -27,6 +27,7 @@
       PublishDiagnosticsParams
       Range
       RenameFile
+      SemanticTokens
       SymbolKind
       SymbolInformation
       TextDocumentEdit
@@ -237,6 +238,12 @@
                                           (.setData (:data %1))))))
 
 (s/def ::code-lenses (s/coll-of ::code-lens))
+
+(s/def ::semantic-tokens (s/and (s/keys :req-un [::data]
+                                  :opt-un [::result-id])
+                                (s/conformer #(doto (SemanticTokens. (:result-id %1)
+                                                                     (java.util.ArrayList. (:data %1))))))) ;;TODO need ArrayList?
+
 
 (defn debeaner [inst]
   (when inst

--- a/src/clojure_lsp/interop.clj
+++ b/src/clojure_lsp/interop.clj
@@ -397,8 +397,7 @@
         (update :cljfmt kwd-keys)
         (update-in [:cljfmt :indents] clean-symbol-map)
         (update :document-formatting? (fnil identity true))
-        (update :document-range-formatting? (fnil identity true))
-        (update :semantic-tokens? (fnil identity false)))))
+        (update :document-range-formatting? (fnil identity true)))))
 
 (defn document->decoded-uri [document]
   (-> document

--- a/src/clojure_lsp/main.clj
+++ b/src/clojure_lsp/main.clj
@@ -421,12 +421,13 @@
                                      (.setDocumentSymbolProvider true)
                                      (.setDocumentHighlightProvider true)
                                      (.setWorkspaceSymbolProvider true)
-                                     (.setSemanticTokensProvider (doto (SemanticTokensWithRegistrationOptions.)
-                                                                   (.setLegend (doto (SemanticTokensLegend.
-                                                                                       semantic-tokens/token-types-str
-                                                                                       semantic-tokens/token-modifiers)))
-                                                                   (.setRange false)
-                                                                   (.setFull true)))
+                                     (.setSemanticTokensProvider (when (:semantic-tokens? c-settings)
+                                                                   (doto (SemanticTokensWithRegistrationOptions.)
+                                                                     (.setLegend (doto (SemanticTokensLegend.
+                                                                                         semantic-tokens/token-types-str
+                                                                                         semantic-tokens/token-modifiers)))
+                                                                     (.setRange false)
+                                                                     (.setFull true))))
                                      (.setExecuteCommandProvider (doto (ExecuteCommandOptions.)
                                                                    (.setCommands (keys handlers/refactorings))))
                                      (.setTextDocumentSync (doto (TextDocumentSyncOptions.)
@@ -434,6 +435,7 @@
                                                              (.setChange TextDocumentSyncKind/Full)
                                                              (.setSave (SaveOptions. true))))
                                      (.setCompletionProvider (CompletionOptions. true [])))))))))
+
     (^void initialized [^InitializedParams params]
       (log/warn "Initialized" params)
       (go :initialized

--- a/src/clojure_lsp/main.clj
+++ b/src/clojure_lsp/main.clj
@@ -403,41 +403,42 @@
     (^CompletableFuture initialize [^InitializeParams params]
       (go :initialize
           (end
-            (let [c-settings (client-settings params)]
-              (log/warn "Initialize")
+            (do
+              (log/info "Initializing...")
               (#'handlers/initialize (.getRootUri params)
                                      (client-capabilities params)
-                                     c-settings)
-              (CompletableFuture/completedFuture
-                (InitializeResult. (doto (ServerCapabilities.)
-                                     (.setHoverProvider true)
-                                     (.setCodeActionProvider true)
-                                     (.setCodeLensProvider (CodeLensOptions. true))
-                                     (.setReferencesProvider true)
-                                     (.setRenameProvider true)
-                                     (.setDefinitionProvider true)
-                                     (.setDocumentFormattingProvider (:document-formatting? c-settings))
-                                     (.setDocumentRangeFormattingProvider (:document-range-formatting? c-settings))
-                                     (.setDocumentSymbolProvider true)
-                                     (.setDocumentHighlightProvider true)
-                                     (.setWorkspaceSymbolProvider true)
-                                     (.setSemanticTokensProvider (when (:semantic-tokens? c-settings)
-                                                                   (doto (SemanticTokensWithRegistrationOptions.)
-                                                                     (.setLegend (doto (SemanticTokensLegend.
-                                                                                         semantic-tokens/token-types-str
-                                                                                         semantic-tokens/token-modifiers)))
-                                                                     (.setRange false)
-                                                                     (.setFull true))))
-                                     (.setExecuteCommandProvider (doto (ExecuteCommandOptions.)
-                                                                   (.setCommands (keys handlers/refactorings))))
-                                     (.setTextDocumentSync (doto (TextDocumentSyncOptions.)
-                                                             (.setOpenClose true)
-                                                             (.setChange TextDocumentSyncKind/Full)
-                                                             (.setSave (SaveOptions. true))))
-                                     (.setCompletionProvider (CompletionOptions. true [])))))))))
+                                     (client-settings params))
+              (let [settings (:settings @db/db)]
+                (CompletableFuture/completedFuture
+                  (InitializeResult. (doto (ServerCapabilities.)
+                                       (.setHoverProvider true)
+                                       (.setCodeActionProvider true)
+                                       (.setCodeLensProvider (CodeLensOptions. true))
+                                       (.setReferencesProvider true)
+                                       (.setRenameProvider true)
+                                       (.setDefinitionProvider true)
+                                       (.setDocumentFormattingProvider (:document-formatting? settings))
+                                       (.setDocumentRangeFormattingProvider (:document-range-formatting? settings))
+                                       (.setDocumentSymbolProvider true)
+                                       (.setDocumentHighlightProvider true)
+                                       (.setWorkspaceSymbolProvider true)
+                                       (.setSemanticTokensProvider (when (:semantic-tokens? settings)
+                                                                     (doto (SemanticTokensWithRegistrationOptions.)
+                                                                       (.setLegend (doto (SemanticTokensLegend.
+                                                                                           semantic-tokens/token-types-str
+                                                                                           semantic-tokens/token-modifiers)))
+                                                                       (.setRange false)
+                                                                       (.setFull true))))
+                                       (.setExecuteCommandProvider (doto (ExecuteCommandOptions.)
+                                                                     (.setCommands (keys handlers/refactorings))))
+                                       (.setTextDocumentSync (doto (TextDocumentSyncOptions.)
+                                                               (.setOpenClose true)
+                                                               (.setChange TextDocumentSyncKind/Full)
+                                                               (.setSave (SaveOptions. true))))
+                                       (.setCompletionProvider (CompletionOptions. true []))))))))))
 
     (^void initialized [^InitializedParams params]
-      (log/warn "Initialized" params)
+      (log/info "Initialized" params)
       (go :initialized
           (end
             (doto

--- a/src/clojure_lsp/parser.clj
+++ b/src/clojure_lsp/parser.clj
@@ -46,6 +46,64 @@
    :usages []
    :ignored? false})
 
+(def default-macro-defs
+  {'clojure.core.match/match [:element {:element [:params :bound-element] :repeat true}]
+   'clojure.core.async/go-loop [:params :bound-elements]
+   'clojure.core/as-> [:element :param :bound-elements]
+   'clojure.core/catch [:element :param :bound-elements]
+   'clojure.core/comment [:elements]
+   'clojure.core/declare [{:element :declaration :forward? true :repeat true}]
+   'clojure.core/defmethod [:element :element :function-params-and-bodies]
+   'clojure.core/defprotocol [{:element :declaration :declare-class? true :doc? true} {:element :element :pred :string} {:element :fn-spec :repeat true :tags #{:method :declare}}]
+   'clojure.core/proxy [:element :element {:element :fn-spec :repeat true :tags #{:method :norename}}]
+   'clojure.core/reify [{:element :class-and-methods}]
+   'clojure.core/quote []
+   'clojure.test/are [:params :bound-element :elements]
+   'clojure.test/deftest [{:element :declaration :tags #{:unused}} :elements]
+   'clojure.test/testing [{:element :declaration :tags #{:unused}} :elements]
+   'cljs.core.match/match [:element {:element [:params :bound-element] :repeat true}]
+   'cljs.core.async/go-loop [:params :bound-elements]
+   'cljs.core/as-> [:element :param :bound-elements]
+   'cljs.core/catch [:element :param :bound-elements]
+   'cljs.core/declare [{:element :declaration :repeat true}]
+   'cljs.core/defmethod [:element :element :function-params-and-bodies]
+   'cljs.core/defprotocol [{:element :declaration :declare-class? true :doc? true} {:element :element :pred :string} {:element :fn-spec :repeat true :tags #{:method :declare}}]
+   'cljs.core/proxy [:element :element {:element :fn-spec :repeat true :tags #{:method :norename}}]
+   'cljs.core/reify [{:element :class-and-methods}]
+   'cljs.test/are [:params :bound-element :elements]
+   'cljs.test/deftest [{:element :declaration :tags #{:unused}} :elements]
+   'clojure.spec.alpha/fdef [{:element :declaration :forward? true} :elements]
+   'compojure.core/ANY [:element :param :bound-elements]
+   'compojure.core/DELETE [:element :param :bound-elements]
+   'compojure.core/GET [:element :param :bound-elements]
+   'compojure.core/PATCH [:element :param :bound-elements]
+   'compojure.core/POST [:element :param :bound-elements]
+   'compojure.core/PUT [:element :param :bound-elements]
+   'compojure.core/context [:element :param :bound-elements]
+   'compojure.core/defroutes [:declaration :elements]
+   'korma.core/defentity [:declaration :elements]
+   'net.cgrand.enlive-html/deftemplate [:declaration :element :params :bound-elements]
+   'outpace.config/defconfig [:declaration :element]
+   'outpace.config/defconfig! [:declaration :element]
+   're-frame.core/reg-event-db [{:element :declaration :signature [:next :next :next :right]} :element]
+   're-frame.core/reg-event-fx [{:element :declaration :signature [:next :next :next :right]} :element]
+   're-frame.core/reg-sub [{:element :declaration :signature [:rightmost :next :next :next :right]} :element :element]
+   'schema.macros/try-catchall [{:element :bound-elements :sub-forms {'catch [:param :bound-elements]}}]
+   'slingshot.slingshot/try+ [{:element :bound-elements :sub-forms {'else [:elements]}}]
+   'schema.core/defn [{:element :declaration
+                       :doc? [{:pred :keyword} {:pred :follows-constant :constant :-}]
+                       :attr-map? [{:pred :keyword} {:pred :follows-constant :constant :-} {:pred :string}]
+                       :signature-style :typed
+                       :signature [{:pred :keyword} {:pred :follows-constant :constant :-} {:pred :string} {:pred :map}]}
+                      {:element :element :pred :keyword}
+                      {:element :element :pred :follows-constant :constant :-}
+                      {:element :element :pred :string}
+                      {:element :element :pred :map}
+                      {:element :function-params-and-bodies
+                       :signature-style :typed}]
+   'midje.sweet/fact [{:element :bound-elements :sub-forms {'=> [] '=not=> [] '=deny=> [] '=expands-to=> [] '=future=> [] 'provided [:elements]}}]
+   'midje.sweet/facts [{:element :bound-elements :sub-forms {'=> [] '=not=> [] '=deny=> [] '=expands-to=> [] '=future=> [] 'provided [:elements]}}]})
+
 (defmacro zspy [loc]
   `(do
      (log/warn '~loc (pr-str (z/sexpr ~loc)))
@@ -95,50 +153,53 @@
           java-sym (get java-classes (symbol (string/replace ident-name #"\.$" "")))
           refered (get refers ident-name)
           required-ns (get requires ident-ns)
+          known-macro? (contains? default-macro-defs refered)
           ctr (if (symbol? ident) symbol keyword)]
-      (assoc
-        (if-not ident-ns
-          (cond
-            java-sym {:sym java-sym :tags #{:norename :java}}
-            declaration? {:sym (ctr (name (or ns 'user)) ident-name)}
-            (and (keyword? ident) (= prefix "::")) {:sym (ctr (name ns) ident-name)}
-            (keyword? ident) {:sym ident}
-            (contains? scoped ident) {:sym (ctr (name (get-in scoped [ident :ns])) ident-name) :tags #{:scoped}}
-            declared {:sym declared}
-            refered {:sym refered :tags #{:refered}}
-            (contains? refer-all-syms ident) {:sym (get refer-all-syms ident)}
-            (and (= :clj file-type) (contains? core-refers ident)) {:sym (ctr (name (get core-refers ident)) ident-name) :tags #{:norename}}
-            (and (= :cljs file-type) (contains? cljs-refers ident)) {:sym (ctr (name (get cljs-refers ident)) ident-name) :tags #{:norename}}
-            (string/starts-with? ident-name ".") {:sym ident :tags #{:java :method :norename}}
-            :else {:sym (ctr (name (gensym)) ident-name) :tags #{:unknown}})
-          (cond
-            (and alias-ns
-                 (or
-                   (and (keyword? ident) (= prefix "::"))
-                   (symbol? ident)))
-            {:sym (ctr (name alias-ns) ident-name)}
+      (-> (if-not ident-ns
+            (cond
+              java-sym {:sym java-sym :tags #{:norename :java}}
+              declaration? {:sym (ctr (name (or ns 'user)) ident-name)}
+              (and (keyword? ident) (= prefix "::")) {:sym (ctr (name ns) ident-name)}
+              (keyword? ident) {:sym ident}
+              (contains? scoped ident) {:sym (ctr (name (get-in scoped [ident :ns])) ident-name) :tags #{:scoped}}
+              declared {:sym declared}
+              refered {:sym refered :tags #{:refered}}
+              (contains? refer-all-syms ident) {:sym (get refer-all-syms ident)}
+              (and (= :clj file-type) (contains? core-refers ident)) {:sym (ctr (name (get core-refers ident)) ident-name) :tags #{:norename}}
+              (and (= :cljs file-type) (contains? cljs-refers ident)) {:sym (ctr (name (get cljs-refers ident)) ident-name) :tags #{:norename}}
+              (string/starts-with? ident-name ".") {:sym ident :tags #{:java :method :norename}}
+              :else {:sym (ctr (name (gensym)) ident-name) :tags #{:unknown}})
+            (cond
+              (and alias-ns
+                   (or
+                     (and (keyword? ident) (= prefix "::"))
+                     (symbol? ident)))
+              {:sym (ctr (name alias-ns) ident-name)}
 
-            (and (keyword? ident) (= prefix "::"))
-            {:sym (ctr (name (gensym)) ident-name) :tags #{:unknown} :unknown-ns ident-ns}
+              (and (keyword? ident) (= prefix "::"))
+              {:sym (ctr (name (gensym)) ident-name) :tags #{:unknown} :unknown-ns ident-ns}
 
-            (keyword? ident)
-            {:sym ident}
+              (keyword? ident)
+              {:sym ident}
 
-            required-ns
-            {:sym ident}
+              required-ns
+              {:sym ident}
 
-            (contains? imports ident-ns)
-            {:sym (symbol (name (get imports ident-ns)) ident-name) :tags #{:java :method :norename}}
+              (contains? imports ident-ns)
+              {:sym (symbol (name (get imports ident-ns)) ident-name) :tags #{:java :method :norename}}
 
-            (contains? lang-imports ident-ns)
-            {:sym (symbol (name (get lang-imports ident-ns)) ident-name) :tags #{:java :method :norename}}
+              (contains? lang-imports ident-ns)
+              {:sym (symbol (name (get lang-imports ident-ns)) ident-name) :tags #{:java :method :norename}}
 
-            (and (= :cljs file-type) (= 'js ident-ns))
-            {:sym ident :tags #{:method :norename}}
+              (and (= :cljs file-type) (= 'js ident-ns))
+              {:sym ident :tags #{:method :norename}}
 
-            :else
-            {:sym (ctr (name (gensym)) ident-name) :tags #{:unknown} :unknown-ns ident-ns}))
-        :str ident-str))))
+              :else
+              {:sym (ctr (name (gensym)) ident-name) :tags #{:unknown} :unknown-ns ident-ns}))
+          (assoc :str ident-str)
+          (update :tags #(if known-macro?
+                           (set/union % #{:macro})
+                           (or % #{})))))))
 
 (defn add-reference [context scoped node extra]
   (let [{:keys [row end-row col end-col]} (meta (skip-meta node))
@@ -748,62 +809,6 @@
                   'clojure.core/doto handle-thread}]
 
     (merge handlers (medley/map-keys #(symbol "cljs.core" (name %)) handlers))))
-
-(def default-macro-defs
-  {'clojure.core.match/match [:element {:element [:params :bound-element] :repeat true}]
-   'clojure.core.async/go-loop [:params :bound-elements]
-   'clojure.core/as-> [:element :param :bound-elements]
-   'clojure.core/catch [:element :param :bound-elements]
-   'clojure.core/declare [{:element :declaration :forward? true :repeat true}]
-   'clojure.core/defmethod [:element :element :function-params-and-bodies]
-   'clojure.core/defprotocol [{:element :declaration :declare-class? true :doc? true} {:element :element :pred :string} {:element :fn-spec :repeat true :tags #{:method :declare}}]
-   'clojure.core/proxy [:element :element {:element :fn-spec :repeat true :tags #{:method :norename}}]
-   'clojure.core/reify [{:element :class-and-methods}]
-   'clojure.core/quote []
-   'clojure.test/are [:params :bound-element :elements]
-   'clojure.test/deftest [{:element :declaration :tags #{:unused}} :elements]
-   'cljs.core.match/match [:element {:element [:params :bound-element] :repeat true}]
-   'cljs.core.async/go-loop [:params :bound-elements]
-   'cljs.core/as-> [:element :param :bound-elements]
-   'cljs.core/catch [:element :param :bound-elements]
-   'cljs.core/declare [{:element :declaration :repeat true}]
-   'cljs.core/defmethod [:element :element :function-params-and-bodies]
-   'cljs.core/defprotocol [{:element :declaration :declare-class? true :doc? true} {:element :element :pred :string} {:element :fn-spec :repeat true :tags #{:method :declare}}]
-   'cljs.core/proxy [:element :element {:element :fn-spec :repeat true :tags #{:method :norename}}]
-   'cljs.core/reify [{:element :class-and-methods}]
-   'cljs.test/are [:params :bound-element :elements]
-   'cljs.test/deftest [{:element :declaration :tags #{:unused}} :elements]
-   'clojure.spec.alpha/fdef [{:element :declaration :forward? true} :elements]
-   'compojure.core/ANY [:element :param :bound-elements]
-   'compojure.core/DELETE [:element :param :bound-elements]
-   'compojure.core/GET [:element :param :bound-elements]
-   'compojure.core/PATCH [:element :param :bound-elements]
-   'compojure.core/POST [:element :param :bound-elements]
-   'compojure.core/PUT [:element :param :bound-elements]
-   'compojure.core/context [:element :param :bound-elements]
-   'compojure.core/defroutes [:declaration :elements]
-   'korma.core/defentity [:declaration :elements]
-   'net.cgrand.enlive-html/deftemplate [:declaration :element :params :bound-elements]
-   'outpace.config/defconfig [:declaration :element]
-   'outpace.config/defconfig! [:declaration :element]
-   're-frame.core/reg-event-db [{:element :declaration :signature [:next :next :next :right]} :element]
-   're-frame.core/reg-event-fx [{:element :declaration :signature [:next :next :next :right]} :element]
-   're-frame.core/reg-sub [{:element :declaration :signature [:rightmost :next :next :next :right]} :element :element]
-   'schema.macros/try-catchall [{:element :bound-elements :sub-forms {'catch [:param :bound-elements]}}]
-   'slingshot.slingshot/try+ [{:element :bound-elements :sub-forms {'else [:elements]}}]
-   'schema.core/defn [{:element :declaration
-                       :doc? [{:pred :keyword} {:pred :follows-constant :constant :-}]
-                       :attr-map? [{:pred :keyword} {:pred :follows-constant :constant :-} {:pred :string}]
-                       :signature-style :typed
-                       :signature [{:pred :keyword} {:pred :follows-constant :constant :-} {:pred :string} {:pred :map}]}
-                      {:element :element :pred :keyword}
-                      {:element :element :pred :follows-constant :constant :-}
-                      {:element :element :pred :string}
-                      {:element :element :pred :map}
-                      {:element :function-params-and-bodies
-                       :signature-style :typed}]
-   'midje.sweet/fact [{:element :bound-elements :sub-forms {'=> [] '=not=> [] '=deny=> [] '=expands-to=> [] '=future=> [] 'provided [:elements]}}]
-   'midje.sweet/facts [{:element :bound-elements :sub-forms {'=> [] '=not=> [] '=deny=> [] '=expands-to=> [] '=future=> [] 'provided [:elements]}}]})
 
 (defn- match-pred? [loc {:keys [pred constant]}]
   (let [sexpr (z/sexpr loc)]

--- a/src/clojure_lsp/semantic_tokens.clj
+++ b/src/clojure_lsp/semantic_tokens.clj
@@ -1,7 +1,8 @@
 (ns clojure-lsp.semantic-tokens)
 
 (def token-types
-  [:function])
+  [:function
+   :macro])
 
 (def token-types-str
   (->> token-types
@@ -29,6 +30,9 @@
        (map
          (fn [{:keys [tags] :as usage}]
            (cond
+             (contains? tags :macro)
+             (usage->absolute-token usage :macro)
+
              (contains? tags :refered)
              (usage->absolute-token usage :function))))
        (remove nil?)))
@@ -37,14 +41,14 @@
   [tokens
    index
    [row col length token-type token-modifier :as token]]
-  (let [[previous-row previous-col previous-length _ _] (nth tokens (dec index) nil)]
+  (let [[previous-row previous-col _ _ _] (nth tokens (dec index) nil)]
     (cond
       (nil? previous-row)
       token
 
       (= previous-row row)
       [0
-       (- col (+ previous-col previous-length))
+       (- col previous-col)
        length
        token-type
        token-modifier]

--- a/src/clojure_lsp/semantic_tokens.clj
+++ b/src/clojure_lsp/semantic_tokens.clj
@@ -1,0 +1,64 @@
+(ns clojure-lsp.semantic-tokens)
+
+(def token-types
+  [:function])
+
+(def token-types-str
+  (->> token-types
+       (map name)
+       vec))
+
+(def token-modifiers
+  [])
+
+(def token-modifier -1)
+
+(defn ^:private usage->absolute-token
+  [{:keys [row col end-col]}
+   token-type]
+  [(dec row)
+   (dec col)
+   (- end-col col)
+   (.indexOf token-types token-type)
+   token-modifier])
+
+(defn ^:private full-absolute
+  [usages]
+  (->> usages
+       (sort-by (juxt :row :col))
+       (map
+         (fn [{:keys [tags] :as usage}]
+           (cond
+             (contains? tags :refered)
+             (usage->absolute-token usage :function))))
+       (remove nil?)))
+
+(defn ^:private absolute-token->relative-token
+  [tokens
+   index
+   [row col length token-type token-modifier :as token]]
+  (let [[previous-row previous-col previous-length _ _] (nth tokens (dec index) nil)]
+    (cond
+      (nil? previous-row)
+      token
+
+      (= previous-row row)
+      [0
+       (- col (+ previous-col previous-length))
+       length
+       token-type
+       token-modifier]
+
+      :else
+      [(- row previous-row)
+       col
+       length
+       token-type
+       token-modifier])))
+
+(defn full
+  [usages]
+  (let [absolute-tokens (full-absolute usages)]
+    (->> absolute-tokens
+         (map-indexed (partial absolute-token->relative-token absolute-tokens))
+         flatten)))

--- a/test/clojure_lsp/main_test.clj
+++ b/test/clojure_lsp/main_test.clj
@@ -17,7 +17,4 @@
       (is (= true (:document-formatting? (main/client-settings params))))))
   (testing "document-range-formatting? is set to true if not provided"
     (let [params (InitializeParams.)]
-      (is (= true (:document-range-formatting? (main/client-settings params))))))
-  (testing "semantic-tokens? is set to false if not provided"
-    (let [params (InitializeParams.)]
-      (is (= false (:semantic-tokens? (main/client-settings params)))))))
+      (is (= true (:document-range-formatting? (main/client-settings params)))))))

--- a/test/clojure_lsp/main_test.clj
+++ b/test/clojure_lsp/main_test.clj
@@ -17,4 +17,7 @@
       (is (= true (:document-formatting? (main/client-settings params))))))
   (testing "document-range-formatting? is set to true if not provided"
     (let [params (InitializeParams.)]
-      (is (= true (:document-range-formatting? (main/client-settings params)))))))
+      (is (= true (:document-range-formatting? (main/client-settings params))))))
+  (testing "semantic-tokens? is set to false if not provided"
+    (let [params (InitializeParams.)]
+      (is (= false (:semantic-tokens? (main/client-settings params)))))))

--- a/test/clojure_lsp/parser_test.clj
+++ b/test/clojure_lsp/parser_test.clj
@@ -51,11 +51,14 @@
 (deftest qualify-ident-test
   (let [context {:file-type :clj}]
     (is (= {:sym 'clojure.core/for :tags #{:norename} :str "for"} (parser/qualify-ident 'for context {} false)))
-    (is (= {:sym 'java.lang.Exception :tags #{:norename} :str "Exception"} (parser/qualify-ident 'Exception context {} false)))
-    (is (= {:sym 'java.lang.Exception :tags #{:norename} :str "Exception."} (parser/qualify-ident 'Exception. context {} false)))
-    (is (= {:sym '.getMessage :tags #{:method :norename} :str ".getMessage"} (parser/qualify-ident '.getMessage context {} false)))
-    (is (= {:sym 'java.lang.Thread/sleep :tags #{:method :norename} :str "Thread/sleep"} (parser/qualify-ident 'Thread/sleep context {} false)))
-    (is (= {:sym ':foo :str ":foo"} (parser/qualify-ident :foo context {} false)))))
+    (is (= {:sym 'java.lang.Exception :tags #{:java :norename} :str "Exception"} (parser/qualify-ident 'Exception context {} false)))
+    (is (= {:sym 'java.lang.Exception :tags #{:java :norename} :str "Exception."} (parser/qualify-ident 'Exception. context {} false)))
+    (is (= {:sym '.getMessage :tags #{:java :method :norename} :str ".getMessage"} (parser/qualify-ident '.getMessage context {} false)))
+    (is (= {:sym 'java.lang.Thread/sleep :tags #{:method :norename :java} :str "Thread/sleep"} (parser/qualify-ident 'Thread/sleep context {} false)))
+    (is (= {:sym ':foo :str ":foo"} (parser/qualify-ident :foo context {} false)))
+    (is (= {:sym 'clojure.core/for :tags #{:norename} :str "for"} (parser/qualify-ident 'for context {} false)))
+    (is (= {:sym 'foo.bar/baz :tags #{:refered} :str "baz"}
+           (parser/qualify-ident 'baz (merge context {:refers {"baz" 'foo.bar/baz}}) {} false)))))
 
 (deftest find-references-simple-test
   (testing "simple stuff"

--- a/test/clojure_lsp/parser_test.clj
+++ b/test/clojure_lsp/parser_test.clj
@@ -44,7 +44,7 @@
   (let [zloc (z/of-string "(fn [^String b])")
         context (volatile! {})]
     (parser/handle-fn (z/next zloc) zloc context {} false)
-    (is (= '{"java.lang.String" #{:norename}
+    (is (= '{"java.lang.String" #{:java :norename}
              "b" #{:declare :param}}
            (into {} (map (juxt (comp name :sym) :tags) (:usages @context)))))))
 
@@ -55,7 +55,7 @@
     (is (= {:sym 'java.lang.Exception :tags #{:java :norename} :str "Exception."} (parser/qualify-ident 'Exception. context {} false)))
     (is (= {:sym '.getMessage :tags #{:java :method :norename} :str ".getMessage"} (parser/qualify-ident '.getMessage context {} false)))
     (is (= {:sym 'java.lang.Thread/sleep :tags #{:method :norename :java} :str "Thread/sleep"} (parser/qualify-ident 'Thread/sleep context {} false)))
-    (is (= {:sym ':foo :str ":foo"} (parser/qualify-ident :foo context {} false)))
+    (is (= {:sym ':foo :str ":foo" :tags #{}} (parser/qualify-ident :foo context {} false)))
     (is (= {:sym 'clojure.core/for :tags #{:norename} :str "for"} (parser/qualify-ident 'for context {} false)))
     (is (= {:sym 'foo.bar/baz :tags #{:refered} :str "baz"}
            (parser/qualify-ident 'baz (merge context {:refers {"baz" 'foo.bar/baz}}) {} false)))
@@ -239,7 +239,7 @@
       (is (= 'java.io.File (:sym file-ref)))
       (is (= 'java.io.File/static (:sym file-static-ref)))
       (is (= 'java.util.jar.JarFile (:sym fq-ref)))
-      (is (= #{:norename :method} (set (mapcat :tags usages)))))))
+      (is (= #{:norename :java :method} (set (mapcat :tags usages)))))))
 
 (deftest find-references-keyword-test
   (testing "simple"
@@ -248,7 +248,7 @@
       (is (= [":foo/foo" ":foo" "::foo" "::q/foo" "::x/foo"] (mapv :str usages)))
       (is (= [:foo/foo :foo :bar/foo :qux/foo] (butlast (mapv :sym usages))))
       (is (= :foo (:sym (second usages))))
-      (is (nil? (seq (remove nil? (mapv :tags (butlast usages))))))
+      (is (= [#{} #{} #{} #{}] (seq (remove nil? (mapv :tags (butlast usages))))))
       (is (not= 'x (namespace (:sym (last usages)))))
       (is (not= 'user (namespace (:sym (last usages)))))
       (is (= #{:unknown} (:tags (last usages))))))
@@ -258,7 +258,7 @@
           [a1 a2 b1 b2 c1 c2 d1 d2 e1 e2 f1 f2 :as usages] (drop 5 (parser/find-usages code :clj {}))]
       (is (= [":foo/a" ":foo/a" ":b" ":b" "::c" "::c" "d" "d" "::q/e" "::q/e" "::x/f" "::x/f"] (mapv :str usages)))
       (is (= [:foo/a :b :bar/c :d :qux/e] (map :sym [a1 b1 c1 d1 e1])))
-      (is (nil? (seq (remove nil? (mapv :tags [a1 b1 c1 d1 e1])))))
+      (is (= [#{} #{} #{} #{}] (seq (remove nil? (mapv :tags [a1 b1 c1 d1 e1])))))
       (is (not= 'x (namespace (:sym (last usages)))))
       (is (not= 'user (namespace (:sym (last usages)))))
       (is (= #{:unknown} (:tags f1)))
@@ -345,7 +345,7 @@
     (is (= '[clojure.core/def user/x clojure.core/comment user/x clojure.core/def] (subvec (mapv :sym usages) 0 5)))
     (is (= '[user/y user/x] (subvec (mapv :sym usages) 6)))
     (is (not= 'user (namespace (:sym def-usage))))
-    (is (= #{:declare} (:tags def-usage))))
+    (is (= #{:declare :public} (:tags def-usage))))
   (let [code "(defn x [] #_y 1)"
         usages (parser/find-usages code :clj {})]
     (is (= 3 (count (map :sym usages)))))

--- a/test/clojure_lsp/parser_test.clj
+++ b/test/clojure_lsp/parser_test.clj
@@ -58,7 +58,9 @@
     (is (= {:sym ':foo :str ":foo"} (parser/qualify-ident :foo context {} false)))
     (is (= {:sym 'clojure.core/for :tags #{:norename} :str "for"} (parser/qualify-ident 'for context {} false)))
     (is (= {:sym 'foo.bar/baz :tags #{:refered} :str "baz"}
-           (parser/qualify-ident 'baz (merge context {:refers {"baz" 'foo.bar/baz}}) {} false)))))
+           (parser/qualify-ident 'baz (merge context {:refers {"baz" 'foo.bar/baz}}) {} false)))
+    (is (= {:sym 'clojure.test/deftest :tags #{:refered :macro} :str "deftest"}
+           (parser/qualify-ident 'deftest (merge context {:refers {"deftest" 'clojure.test/deftest}}) {} false)))))
 
 (deftest find-references-simple-test
   (testing "simple stuff"

--- a/test/clojure_lsp/parser_test.clj
+++ b/test/clojure_lsp/parser_test.clj
@@ -50,13 +50,13 @@
 
 (deftest qualify-ident-test
   (let [context {:file-type :clj}]
-    (is (= {:sym 'clojure.core/for :tags #{:norename} :str "for"} (parser/qualify-ident 'for context {} false)))
+    (is (= {:sym 'clojure.core/for :tags #{:norename :core} :str "for"} (parser/qualify-ident 'for context {} false)))
     (is (= {:sym 'java.lang.Exception :tags #{:java :norename} :str "Exception"} (parser/qualify-ident 'Exception context {} false)))
     (is (= {:sym 'java.lang.Exception :tags #{:java :norename} :str "Exception."} (parser/qualify-ident 'Exception. context {} false)))
     (is (= {:sym '.getMessage :tags #{:java :method :norename} :str ".getMessage"} (parser/qualify-ident '.getMessage context {} false)))
     (is (= {:sym 'java.lang.Thread/sleep :tags #{:method :norename :java} :str "Thread/sleep"} (parser/qualify-ident 'Thread/sleep context {} false)))
     (is (= {:sym ':foo :str ":foo" :tags #{}} (parser/qualify-ident :foo context {} false)))
-    (is (= {:sym 'clojure.core/for :tags #{:norename} :str "for"} (parser/qualify-ident 'for context {} false)))
+    (is (= {:sym 'clojure.core/for :tags #{:norename :core} :str "for"} (parser/qualify-ident 'for context {} false)))
     (is (= {:sym 'foo.bar/baz :tags #{:refered} :str "baz"}
            (parser/qualify-ident 'baz (merge context {:refers {"baz" 'foo.bar/baz}}) {} false)))
     (is (= {:sym 'clojure.test/deftest :tags #{:refered :macro} :str "deftest"}

--- a/test/clojure_lsp/semantic_tokens_test.clj
+++ b/test/clojure_lsp/semantic_tokens_test.clj
@@ -81,7 +81,8 @@
           usages (parser/find-usages code :clj {})]
       (is (= [1 9 3 0 -1
               1 0 3 0 -1
-              2 0 3 0 -1]
+              1 1 7 1 -1
+              1 0 3 0 -1]
              (semantic-tokens/full usages)))))
   (testing "testing user refered tokens"
     (let [code (long-str "(ns some.ns (:require [foo.bar :refer [baz]]))"
@@ -94,4 +95,9 @@
                          "(deftest some-test 1)")
           usages (parser/find-usages code :clj {})]
       (is (= [1 1 7 1 -1]
+             (semantic-tokens/full usages)))))
+  (testing "testing macro core tokens"
+    (let [code (long-str "(comment 1)")
+          usages (parser/find-usages code :clj {})]
+      (is (= [0 1 7 1 -1]
              (semantic-tokens/full usages))))))

--- a/test/clojure_lsp/semantic_tokens_test.clj
+++ b/test/clojure_lsp/semantic_tokens_test.clj
@@ -1,0 +1,91 @@
+(ns clojure-lsp.semantic-tokens-test
+  (:require [clojure-lsp.parser :as parser]
+            [clojure-lsp.semantic-tokens :as semantic-tokens]
+            [clojure.string :as clojure.string]
+            [clojure.test :refer :all]))
+
+(defn ^:private ->token
+  [usage token-type]
+  (#'semantic-tokens/usage->absolute-token usage token-type))
+
+(def function-usage-a
+  {:row 7
+   :end-row 7
+   :col 4
+   :end-col 7
+   :file-type :clj
+   :sym 'foo.bar/baz
+   :str "baz"
+   :argc 2})
+
+(def function-usage-b
+  {:row 7
+   :end-row 7
+   :col 11
+   :end-col 14
+   :file-type :clj
+   :sym 'foo.bar/baz
+   :str "baz"
+   :argc 2})
+
+(def function-usage-c
+  {:row 9
+   :end-row 9
+   :col 3
+   :end-col 6
+   :file-type :clj
+   :sym 'foo.bar/baz
+   :str "baz"
+   :argc 2})
+
+(def function-usages
+  [function-usage-a
+   function-usage-b
+   function-usage-c])
+
+(def function-tokens
+  (map #(->token % :function) function-usages))
+
+(defn long-str [& strings] (clojure.string/join "\n" strings))
+
+(deftest usage->absolute-token
+  (is (= [6 3 3 0 -1]
+         (#'semantic-tokens/usage->absolute-token function-usage-a
+                                                  :function))))
+
+(deftest absolute-token->relative-token
+  (testing "without previous token"
+    (is (= [6 3 3 0 -1]
+           (#'semantic-tokens/absolute-token->relative-token function-tokens
+                                                             0
+                                                             (->token function-usage-a :function)))))
+  (testing "same line token"
+    (is (= [0 4 3 0 -1]
+           (#'semantic-tokens/absolute-token->relative-token function-tokens
+                                                             1
+                                                             (->token function-usage-b :function)))))
+
+  (testing "other line token"
+    (is (= [2 2 3 0 -1]
+           (#'semantic-tokens/absolute-token->relative-token function-tokens
+                                                             2
+                                                             (->token function-usage-c :function))))))
+
+(deftest full
+  (testing "testing tokens order"
+    (let [code (long-str "(ns some.ns (:require [foo.bar :refer [baz]]))"
+                         "(def bla baz)"
+                         "baz"
+                         "(comment)"
+                         "baz")
+          usages (parser/find-usages code :clj {})]
+      (is (= [1 9 3 0 -1
+              1 0 3 0 -1
+              2 0 3 0 -1]
+             (semantic-tokens/full usages)))))
+  (testing "testing refered tokens"
+    (let [code (long-str "(ns some.ns (:require [foo.bar :refer [baz]]))"
+                         "(def bla baz)")
+          usages (parser/find-usages code :clj {})]
+      (is (= [1 9 3 0 -1]
+             (semantic-tokens/full usages))))))


### PR DESCRIPTION
[Spec](https://microsoft.github.io/language-server-protocol/specifications/specification-current/#textDocument_semanticTokens)

This PR starts to use semantic tokens, it adds just basic support and with a flag disabled by default: `semantic-tokens?`.
It adds supports just for `full` semantic tokens client request which returns semantic tokens for a whole document, there are ways to improve performance according to the spec, like `delta` request.

Also, it adds just 2 tokens as a start: `macro` and `function` (for now, just for referred symbols) 

![image](https://user-images.githubusercontent.com/7820865/103142620-c82fdd80-46e4-11eb-956d-952dc63f6e47.png)
